### PR TITLE
Add simple Tauri CLI

### DIFF
--- a/ytapp/.gitignore
+++ b/ytapp/.gitignore
@@ -22,3 +22,7 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Rust
+src-tauri/target
+src-tauri/Cargo.lock

--- a/ytapp/package.json
+++ b/ytapp/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "ytapp",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "vite",
+    "build": "vite build",
+    "cli": "ts-node src/cli.ts"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@tauri-apps/api": "^2.5.0",
+    "commander": "^14.0.0"
+  },
+  "devDependencies": {
+    "vite": "^4.0.0",
+    "typescript": "^4.0.0",
+    "ts-node": "^10.9.2"
+  }
+}

--- a/ytapp/public/index.html
+++ b/ytapp/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Youtube Automation</title>
+</head>
+<body>
+    <div id="root"></div>
+</body>
+</html>

--- a/ytapp/src-tauri/Cargo.toml
+++ b/ytapp/src-tauri/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "ytapp"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tauri = "1"
+
+[build-dependencies]

--- a/ytapp/src-tauri/src/main.rs
+++ b/ytapp/src-tauri/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Tauri backend placeholder");
+}

--- a/ytapp/src/App.tsx
+++ b/ytapp/src/App.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const App: React.FC = () => {
+    return (
+        <div>
+            <h1>Youtube Automation</h1>
+            <p>Project setup placeholder</p>
+        </div>
+    );
+};
+
+export default App;

--- a/ytapp/src/cli.ts
+++ b/ytapp/src/cli.ts
@@ -1,0 +1,46 @@
+import { program } from 'commander';
+import { invoke } from '@tauri-apps/api/tauri';
+
+async function generateVideo(params: { file: string; output?: string }) {
+  return await invoke('generate_video', params);
+}
+
+async function uploadVideo(params: { file: string }) {
+  return await invoke('upload_video', params);
+}
+
+program
+  .name('ytcli')
+  .description('CLI for generating and uploading videos')
+  .version('0.1.0');
+
+program
+  .command('generate')
+  .description('Generate video from audio')
+  .argument('<file>', 'audio file path')
+  .option('-o, --output <output>', 'output video path')
+  .action(async (file: string, options: { output?: string }) => {
+    try {
+      const result = await generateVideo({ file, output: options.output });
+      console.log(result);
+    } catch (err) {
+      console.error('Error generating video:', err);
+      process.exitCode = 1;
+    }
+  });
+
+program
+  .command('upload')
+  .description('Upload video to YouTube')
+  .argument('<file>', 'video file path')
+  .action(async (file: string) => {
+    try {
+      const result = await uploadVideo({ file });
+      console.log(result);
+    } catch (err) {
+      console.error('Error uploading video:', err);
+      process.exitCode = 1;
+    }
+  });
+
+program.parseAsync(process.argv);

--- a/ytapp/src/features/batch/index.ts
+++ b/ytapp/src/features/batch/index.ts
@@ -1,0 +1,1 @@
+// Batch processing placeholder

--- a/ytapp/src/features/processing/index.ts
+++ b/ytapp/src/features/processing/index.ts
@@ -1,0 +1,1 @@
+// Processing feature placeholder

--- a/ytapp/src/features/transcription/index.ts
+++ b/ytapp/src/features/transcription/index.ts
@@ -1,0 +1,1 @@
+// Transcription feature placeholder

--- a/ytapp/src/features/youtube/index.ts
+++ b/ytapp/src/features/youtube/index.ts
@@ -1,0 +1,1 @@
+// YouTube integration placeholder

--- a/ytapp/src/main.tsx
+++ b/ytapp/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const container = document.getElementById('root');
+if (container) {
+    const root = createRoot(container);
+    root.render(<App />);
+}

--- a/ytapp/tsconfig.json
+++ b/ytapp/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "esModuleInterop": true,
+    "strict": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- update package.json with CLI deps and script
- ignore Rust build artifacts
- add tsconfig for CLI compilation
- implement `ytcli` TypeScript CLI using commander

## Testing
- `cargo check` *(fails: `glib-2.0` not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845e73502748331940dabb26ce812fc