### PR TITLE
Implement batch generation and caption styling

### DIFF
--- a/ytapp/src/App.tsx
+++ b/ytapp/src/App.tsx
@@ -1,10 +1,55 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { generateVideo } from './features/processing';
 
 const App: React.FC = () => {
+    const [file, setFile] = useState('');
+    const [captions, setCaptions] = useState('');
+    const [intro, setIntro] = useState('');
+    const [outro, setOutro] = useState('');
+    const [font, setFont] = useState('');
+    const [size, setSize] = useState(24);
+    const [position, setPosition] = useState('bottom');
+
+    const handleGenerate = async () => {
+        if (!file) return;
+        await generateVideo({
+            file,
+            captions: captions || undefined,
+            captionOptions: { font: font || undefined, size, position },
+            intro: intro || undefined,
+            outro: outro || undefined,
+        });
+    };
+
     return (
         <div>
             <h1>Youtube Automation</h1>
-            <p>Project setup placeholder</p>
+            <div>
+                <input type="text" placeholder="Audio file" value={file} onChange={(e) => setFile(e.target.value)} />
+            </div>
+            <div>
+                <input type="text" placeholder="Captions file" value={captions} onChange={(e) => setCaptions(e.target.value)} />
+            </div>
+            <div>
+                <input type="text" placeholder="Intro video" value={intro} onChange={(e) => setIntro(e.target.value)} />
+            </div>
+            <div>
+                <input type="text" placeholder="Outro video" value={outro} onChange={(e) => setOutro(e.target.value)} />
+            </div>
+            <div>
+                <input type="text" placeholder="Font" value={font} onChange={(e) => setFont(e.target.value)} />
+            </div>
+            <div>
+                <input type="number" placeholder="Font size" value={size} onChange={(e) => setSize(parseInt(e.target.value) || 0)} />
+            </div>
+            <div>
+                <select value={position} onChange={(e) => setPosition(e.target.value)}>
+                    <option value="top">Top</option>
+                    <option value="center">Center</option>
+                    <option value="bottom">Bottom</option>
+                </select>
+            </div>
+            <button onClick={handleGenerate}>Generate</button>
         </div>
     );
 };

--- a/ytapp/src/features/batch/index.ts
+++ b/ytapp/src/features/batch/index.ts
@@ -1,1 +1,24 @@
-// Batch processing placeholder
+import { GenerateParams, generateVideo } from '../processing';
+
+export interface BatchOptions extends Omit<GenerateParams, 'file' | 'output'> {
+    outputDir?: string;
+}
+
+export async function generateBatch(files: string[], options: BatchOptions): Promise<string[]> {
+    const results: string[] = [];
+    for (const file of files) {
+        const output = options.outputDir
+            ? `${options.outputDir}/${file.split('/').pop()?.replace(/\.[^/.]+$/, '.mp4')}`
+            : undefined;
+        const res = await generateVideo({
+            file,
+            output,
+            captions: options.captions,
+            captionOptions: options.captionOptions,
+            intro: options.intro,
+            outro: options.outro,
+        });
+        results.push(res);
+    }
+    return results;
+}

--- a/ytapp/src/features/processing/index.ts
+++ b/ytapp/src/features/processing/index.ts
@@ -1,5 +1,20 @@
 import { invoke } from '@tauri-apps/api/tauri';
 
-export async function generateVideo(file: string, output?: string): Promise<string> {
-    return await invoke('generate_video', { file, output });
+export interface CaptionOptions {
+    font?: string;
+    size?: number;
+    position?: string;
+}
+
+export interface GenerateParams {
+    file: string;
+    output?: string;
+    captions?: string;
+    captionOptions?: CaptionOptions;
+    intro?: string;
+    outro?: string;
+}
+
+export async function generateVideo(params: GenerateParams): Promise<string> {
+    return await invoke('generate_video', params);
 }


### PR DESCRIPTION
## Summary
- enable caption styling in Tauri `generate_video`
- expose caption options and new batch command in the CLI
- implement batch generation helper for the frontend
- add caption and intro/outro fields to the React UI

## Testing
- `npm --prefix ytapp run build`
- `cargo build --manifest-path ytapp/src-tauri/Cargo.toml` *(fails: gobject-2.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845f4cee5a483318cc8fb0f835bc123