### PR TITLE
Implement Whisper-based transcription

### DIFF
--- a/ytapp/src-tauri/Cargo.toml
+++ b/ytapp/src-tauri/Cargo.toml
@@ -7,3 +7,5 @@ edition = "2021"
 tauri = { version = "1", features = ["api-all"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+whisper_cli = "0.1.5"
+tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
## Summary
- add `whisper_cli` and `tokio` dependencies to the Tauri backend
- implement `transcribe_audio` using whisper to output `.srt`

## Testing
- `cargo check` *(fails: glib-2.0 / gdk-3.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6845f6fc567083318ed68e6e363d9cfe