### PR TITLE
Add YouTube upload support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -50,6 +50,9 @@
   * `https://www.googleapis.com/auth/youtube.upload`
 * Token storage (encrypted local storage)
 * Upload video via YouTube Data API v3
+  * Implemented in Rust backend using google-youtube3 crate
+  * Requires `client_secret.json` path via `YOUTUBE_CLIENT_SECRET` env variable
+  * Tokens stored in `youtube_tokens.json`
 * Batch upload support
 
 ---

--- a/ytapp/src-tauri/Cargo.toml
+++ b/ytapp/src-tauri/Cargo.toml
@@ -9,3 +9,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 whisper_cli = "0.1.5"
 tokio = { version = "1", features = ["full"] }
+google-youtube3 = { version = "6" }
+hyper-rustls = "0.27"
+hyper-util = "0.1"
+yup-oauth2 = "11"

--- a/ytapp/src-tauri/src/main.rs
+++ b/ytapp/src-tauri/src/main.rs
@@ -1,7 +1,11 @@
-use std::{path::PathBuf, process::Command};
+use std::{path::{Path, PathBuf}, process::Command, io::BufReader};
 use tauri::command;
 use serde::Deserialize;
 use whisper_cli::{Language, Model, Size, Whisper};
+use google_youtube3::{api::Video, YouTube};
+use yup_oauth2::{InstalledFlowAuthenticator, InstalledFlowReturnMethod};
+use hyper_rustls::HttpsConnectorBuilder;
+use hyper_util::{client::legacy::Client, rt::TokioExecutor};
 
 #[derive(Deserialize, Default)]
 struct CaptionOptions {
@@ -71,9 +75,56 @@ fn generate_video(params: GenerateParams) -> Result<String, String> {
 }
 
 #[command]
-fn upload_video(file: String) -> Result<String, String> {
-    // Placeholder for YouTube upload implementation
-    Ok(format!("Upload not implemented. Received file: {}", file))
+async fn upload_video(file: String) -> Result<String, String> {
+    let secret_path = std::env::var("YOUTUBE_CLIENT_SECRET").unwrap_or_else(|_| "client_secret.json".into());
+    let secret = yup_oauth2::read_application_secret(secret_path)
+        .await
+        .map_err(|e| format!("Failed to read client secret: {}", e))?;
+
+    let auth = InstalledFlowAuthenticator::builder(secret, InstalledFlowReturnMethod::HTTPRedirect)
+        .persist_tokens_to_disk("youtube_tokens.json")
+        .build()
+        .await
+        .map_err(|e| format!("Auth error: {}", e))?;
+
+    let client = Client::builder(TokioExecutor::new())
+        .build(
+            HttpsConnectorBuilder::new()
+                .with_native_roots()
+                .https_or_http()
+                .enable_http1()
+                .build(),
+        );
+
+    let mut hub = YouTube::new(client, auth);
+
+    let file_name = Path::new(&file)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("upload");
+
+    let video = Video {
+        snippet: Some(google_youtube3::api::VideoSnippet {
+            title: Some(file_name.to_string()),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let f = std::fs::File::open(&file).map_err(|e| format!("Failed to open file: {}", e))?;
+    let size = f.metadata().map_err(|e| e.to_string())?.len();
+    let mut reader = std::io::BufReader::new(f);
+
+    let response = hub
+        .videos()
+        .insert(video)
+        .add_part("snippet")
+        .upload_resumable(&mut reader, "video/mp4".parse().unwrap())
+        .await
+        .map_err(|e| format!("Upload failed: {}", e))?;
+
+    let id = response.1.id.unwrap_or_default();
+    Ok(format!("Uploaded video ID: {}", id))
 }
 
 #[command]


### PR DESCRIPTION
## Summary
- integrate google-youtube3 and yup-oauth2 crates
- implement OAuth-based video upload command in Rust backend
- document new upload requirement and token path

## Testing
- `cargo check` *(fails: gdk-3.0 pkg-config missing)*
- `npm run build` *(fails: Could not resolve entry module)*

------
https://chatgpt.com/codex/tasks/task_e_6845f960c4c08331925539435af53456