### PR TITLE
Implement batch upload feature

### DIFF
--- a/ytapp/src/cli.ts
+++ b/ytapp/src/cli.ts
@@ -26,6 +26,10 @@ async function uploadVideo(params: { file: string }) {
   return await invoke('upload_video', params);
 }
 
+async function uploadVideos(params: { files: string[] }) {
+  return await invoke('upload_videos', params);
+}
+
 async function transcribeAudio(params: { file: string }) {
   return await invoke('transcribe_audio', params);
 }
@@ -119,6 +123,20 @@ program
       console.log(result);
     } catch (err) {
       console.error('Error uploading video:', err);
+      process.exitCode = 1;
+    }
+  });
+
+program
+  .command('upload-batch')
+  .description('Upload multiple videos to YouTube')
+  .argument('<files...>', 'video files')
+  .action(async (files: string[]) => {
+    try {
+      const results = await uploadVideos({ files });
+      results.forEach((res) => console.log(res));
+    } catch (err) {
+      console.error('Error uploading videos:', err);
       process.exitCode = 1;
     }
   });

--- a/ytapp/src/features/youtube/index.ts
+++ b/ytapp/src/features/youtube/index.ts
@@ -3,3 +3,7 @@ import { invoke } from '@tauri-apps/api/tauri';
 export async function uploadVideo(file: string): Promise<string> {
     return await invoke('upload_video', { file });
 }
+
+export async function uploadVideos(files: string[]): Promise<string[]> {
+    return await invoke('upload_videos', { files });
+}


### PR DESCRIPTION
## Summary
- support uploading multiple videos via Rust backend
- expose new `uploadVideos` function to the frontend
- add `upload-batch` command in CLI

## Testing
- `npm install`
- `npm run cli -- -h` *(fails: Cannot find module '@tauri-apps/api/tauri')*
- `cargo check --manifest-path ytapp/src-tauri/Cargo.toml` *(fails: system library `gio-2.0` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68460075f81883319249148d810efbe1