### PR TITLE
Implement audio file picker component

### DIFF
--- a/ytapp/src/App.tsx
+++ b/ytapp/src/App.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { generateVideo } from './features/processing';
+import FilePicker from './components/FilePicker';
 
 const App: React.FC = () => {
     const [file, setFile] = useState('');
@@ -26,6 +27,10 @@ const App: React.FC = () => {
             <h1>Youtube Automation</h1>
             <div>
                 <input type="text" placeholder="Audio file" value={file} onChange={(e) => setFile(e.target.value)} />
+                <FilePicker label="Browse" onSelect={(p) => {
+                    if (typeof p === 'string') setFile(p);
+                    else if (Array.isArray(p) && p.length) setFile(p[0]);
+                }} />
             </div>
             <div>
                 <input type="text" placeholder="Captions file" value={captions} onChange={(e) => setCaptions(e.target.value)} />

--- a/ytapp/src/components/FilePicker.tsx
+++ b/ytapp/src/components/FilePicker.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { open } from '@tauri-apps/api/dialog';
+
+interface FilePickerProps {
+  multiple?: boolean;
+  onSelect: (paths: string | string[] | null) => void;
+  label?: string;
+}
+
+const FilePicker: React.FC<FilePickerProps> = ({ multiple, onSelect, label }) => {
+  const handleClick = async () => {
+    const selected = await open({ multiple, filters: [
+      { name: 'Audio', extensions: ['mp3', 'wav', 'm4a', 'flac', 'aac'] }
+    ]});
+    onSelect(selected);
+  };
+
+  return (
+    <button onClick={handleClick}>{label || (multiple ? 'Select Files' : 'Select File')}</button>
+  );
+};
+
+export default FilePicker;


### PR DESCRIPTION
## Summary
- add reusable FilePicker component using Tauri dialog API
- integrate FilePicker into main App for selecting audio files

## Testing
- `npm install`
- `cargo check` *(fails: javascriptcoregtk-4.0 not found)*
- `NODE_OPTIONS=--max-old-space-size=512 npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_68460983dfbc8331a0027a7cde94a9ac