### PR TITLE
Add script for Tauri dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.env.tauri

--- a/readme.md
+++ b/readme.md
@@ -104,6 +104,12 @@
 
 ### Setup
 
+Run the helper script to install required system packages on Ubuntu/Debian:
+
+```bash
+./scripts/install_tauri_deps.sh
+```
+
 Install Tauri's system dependencies (Ubuntu/Debian):
 
 ```bash

--- a/scripts/install_tauri_deps.sh
+++ b/scripts/install_tauri_deps.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install system dependencies required for building the Tauri application.
+# Intended for Ubuntu/Debian systems.
+
+DEPS=(
+    libgtk-3-dev
+    libglib2.0-dev
+    libsoup2.4-dev
+    libwebkit2gtk-4.1-dev
+    libjavascriptcoregtk-4.1-dev
+    build-essential
+    pkg-config
+    libssl-dev
+)
+
+if ! command -v apt-get >/dev/null; then
+    echo "This script currently supports apt based systems only." >&2
+    exit 1
+fi
+
+sudo apt-get update
+sudo apt-get install -y "${DEPS[@]}"
+
+PKGCONFIG_DIR=/usr/lib/x86_64-linux-gnu/pkgconfig
+
+# Create compatibility links for Ubuntu 24.04 where only *-4.1.pc files exist
+if [ -f "$PKGCONFIG_DIR/webkit2gtk-4.1.pc" ] && [ ! -f "$PKGCONFIG_DIR/webkit2gtk-4.0.pc" ]; then
+    sudo ln -sf "$PKGCONFIG_DIR/webkit2gtk-4.1.pc" "$PKGCONFIG_DIR/webkit2gtk-4.0.pc"
+    sudo ln -sf "$PKGCONFIG_DIR/webkit2gtk-web-extension-4.1.pc" "$PKGCONFIG_DIR/webkit2gtk-web-extension-4.0.pc"
+fi
+
+if [ -f "$PKGCONFIG_DIR/javascriptcoregtk-4.1.pc" ] && [ ! -f "$PKGCONFIG_DIR/javascriptcoregtk-4.0.pc" ]; then
+    sudo ln -sf "$PKGCONFIG_DIR/javascriptcoregtk-4.1.pc" "$PKGCONFIG_DIR/javascriptcoregtk-4.0.pc"
+fi
+
+# Write PKG_CONFIG_PATH to .env file for tauri\'s build scripts
+echo "PKG_CONFIG_PATH=$PKGCONFIG_DIR" > .env.tauri
+
+cat <<MSG
+System dependencies installed.
+A .env.tauri file has been created with PKG_CONFIG_PATH.
+Source it or add the variable to your shell profile before running cargo.
+MSG


### PR DESCRIPTION
## Summary
- create `install_tauri_deps.sh` script to install Ubuntu/Debian packages used by Tauri and set `PKG_CONFIG_PATH`
- document the script in the project setup instructions
- ignore the generated `.env.tauri` file

## Testing
- `cargo check` *(fails: system library `gdk-3.0` not found)*
- `npm install`


------
https://chatgpt.com/codex/tasks/task_e_684620c46910833186c3fa3b3a2ee3d3