### PR TITLE
Implement Whisper model check on startup

### DIFF
--- a/ytapp/src-tauri/src/main.rs
+++ b/ytapp/src-tauri/src/main.rs
@@ -7,6 +7,8 @@ use std::{
 use tauri::command;
 use serde::Deserialize;
 use whisper_cli::{Language, Model, Size, Whisper};
+mod model_check;
+use model_check::ensure_whisper_model;
 use google_youtube3::{api::Video, YouTube};
 use yup_oauth2::{InstalledFlowAuthenticator, InstalledFlowReturnMethod};
 use hyper_rustls::HttpsConnectorBuilder;
@@ -261,6 +263,7 @@ fn transcribe_audio(file: String) -> Result<String, String> {
 }
 
 fn main() {
+    ensure_whisper_model();
     tauri::Builder::default()
         .invoke_handler(tauri::generate_handler![generate_video, upload_video, upload_videos, transcribe_audio])
         .run(tauri::generate_context!())

--- a/ytapp/src-tauri/src/model_check.rs
+++ b/ytapp/src-tauri/src/model_check.rs
@@ -1,0 +1,9 @@
+use whisper_cli::{Model, Size};
+
+/// Ensure the default Whisper model is present. Downloads it if missing.
+pub fn ensure_whisper_model() {
+    tauri::async_runtime::block_on(async {
+        // download() is a no-op when the model already exists
+        Model::new(Size::Base).download().await;
+    });
+}


### PR DESCRIPTION
## Summary
- add `model_check` utility that ensures the Whisper model is present
- invoke `ensure_whisper_model` before Tauri command handlers run

## Testing
- `npm install`
- `cargo check` *(fails: `glib-2.0` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846322152708331b1e7f94c7b98f2d8