### PR TITLE
Add batch processing UI

### DIFF
--- a/ytapp/src/components/BatchProcessor.tsx
+++ b/ytapp/src/components/BatchProcessor.tsx
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+import FilePicker from './FilePicker';
+import { generateBatchWithProgress } from '../features/batch';
+
+const BatchProcessor: React.FC = () => {
+  const [files, setFiles] = useState<string[]>([]);
+  const [progress, setProgress] = useState(0);
+  const [running, setRunning] = useState(false);
+
+  const handleSelect = (selected: string | string[] | null) => {
+    if (Array.isArray(selected)) {
+      setFiles(selected);
+    } else if (typeof selected === 'string') {
+      setFiles([selected]);
+    } else {
+      setFiles([]);
+    }
+  };
+
+  const startBatch = async () => {
+    if (!files.length) return;
+    setRunning(true);
+    setProgress(0);
+    await generateBatchWithProgress(files, {}, (cur, total) => {
+      const pct = Math.round(((cur + 1) / total) * 100);
+      setProgress(pct);
+    });
+    setRunning(false);
+  };
+
+  return (
+    <div>
+      <h2>Batch Processor</h2>
+      <FilePicker multiple onSelect={handleSelect} label="Select Audio Files" />
+      {files.length > 0 && <p>{files.length} files selected</p>}
+      <button onClick={startBatch} disabled={running || !files.length}>Start</button>
+      {running && (
+        <div>
+          <progress value={progress} max={100} />
+          <span>{progress}%</span>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default BatchProcessor;

--- a/ytapp/src/features/batch/index.ts
+++ b/ytapp/src/features/batch/index.ts
@@ -1,4 +1,5 @@
 import { GenerateParams, generateVideo } from '../processing';
+export type ProgressCallback = (current: number, total: number, file: string) => void;
 
 export interface BatchOptions extends Omit<GenerateParams, 'file' | 'output'> {
     outputDir?: string;
@@ -22,5 +23,28 @@ export async function generateBatch(files: string[], options: BatchOptions): Pro
         });
         results.push(res);
     }
+    return results;
+}
+
+export async function generateBatchWithProgress(files: string[], options: BatchOptions, onProgress?: ProgressCallback): Promise<string[]> {
+    const results: string[] = [];
+    for (let i = 0; i < files.length; i++) {
+        const file = files[i];
+        onProgress?.(i, files.length, file);
+        const output = options.outputDir
+            ? `${options.outputDir}/${file.split('/').pop()?.replace(/\.[^/.]+$/, '.mp4')}`
+            : undefined;
+        const res = await generateVideo({
+            file,
+            output,
+            captions: options.captions,
+            captionOptions: options.captionOptions,
+            background: options.background,
+            intro: options.intro,
+            outro: options.outro,
+        });
+        results.push(res);
+    }
+    onProgress?.(files.length, files.length, '');
     return results;
 }


### PR DESCRIPTION
## Summary
- support progress callbacks in batch generation
- add React component to pick multiple files and show progress

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6846323c79a483319e473208dec024fe