### PR TITLE
Add cross-platform packaging script

### DIFF
--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build the Tauri application for Windows, macOS and Linux.
+# Generated installers are copied into the repository level 'dist' directory.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+APP_DIR="$ROOT_DIR/ytapp"
+DIST_DIR="$ROOT_DIR/dist"
+
+mkdir -p "$DIST_DIR"
+
+build_target() {
+    local target="$1"
+    echo "==> Building target $target"
+    (cd "$APP_DIR" && tauri build --target "$target")
+
+    find "$APP_DIR/src-tauri/target/$target" -path '*/bundle/*' -type f \
+        \( -name '*.exe' -o -name '*.dmg' -o -name '*.AppImage' \) \
+        -exec cp {} "$DIST_DIR/" \;
+}
+
+build_target x86_64-pc-windows-msvc
+build_target x86_64-apple-darwin
+build_target x86_64-unknown-linux-gnu
+


### PR DESCRIPTION
## Summary
- add `scripts/package.sh` to run `tauri build` for Windows, macOS and Linux
- copy generated installers into top-level `dist` directory

## Testing
- `bash -n scripts/package.sh`
- `./scripts/package.sh` *(fails: `tauri: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684632447cac8331bcc0ed52e7654b72