### PR TITLE
Fix compile errors

### DIFF
--- a/ytapp/src-tauri/src/main.rs
+++ b/ytapp/src-tauri/src/main.rs
@@ -17,7 +17,7 @@ mod language;
 mod token_store;
 use token_store::EncryptedTokenStorage;
 
-#[derive(Deserialize, Default)]
+#[derive(Deserialize, Default, Clone)]
 struct CaptionOptions {
     font: Option<String>,
     size: Option<u32>,
@@ -137,7 +137,10 @@ fn build_main_section(params: &GenerateParams, duration: f64) -> Result<PathBuf,
 
 #[command]
 fn generate_video(params: GenerateParams) -> Result<String, String> {
-    let output_path = params.output.unwrap_or_else(|| "output.mp4".to_string());
+    let output_path = params
+        .output
+        .clone()
+        .unwrap_or_else(|| "output.mp4".to_string());
 
     let duration = audio_duration(&params.file)?;
     let main = build_main_section(&params, duration)?;


### PR DESCRIPTION
## Summary
- derive `Clone` for `CaptionOptions`
- avoid moving `params.output` in `generate_video`

## Testing
- `npm install`
- `cargo check` *(fails: could not compile `ytapp`)*
- `npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_68464594523c8331849dc3213bfa16eb