### PR TITLE
Add batch tools and caption styling

### DIFF
--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -6,9 +6,14 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 APP_DIR="$ROOT_DIR/ytapp"
-DIST_DIR="$ROOT_DIR/dist"
+DIST_DIR="${DIST_DIR:-$ROOT_DIR/dist}"
 
 mkdir -p "$DIST_DIR"
+
+if ! command -v tauri >/dev/null; then
+    echo "Tauri CLI not found. Install with 'cargo install tauri-cli'." >&2
+    exit 1
+fi
 
 build_target() {
     local target="$1"

--- a/ytapp/src/App.tsx
+++ b/ytapp/src/App.tsx
@@ -4,9 +4,13 @@ import YouTubeAuthButton from './components/YouTubeAuthButton';
 import GenerateUploadButton from './components/GenerateUploadButton';
 import { GenerateParams } from './features/youtube';
 import FilePicker from './components/FilePicker';
+import BatchPage from './components/BatchPage';
+import FontSelector from './components/FontSelector';
+import SizeSlider from './components/SizeSlider';
 import { languageOptions, Language } from './features/language';
 
 const App: React.FC = () => {
+    const [page, setPage] = useState<'single' | 'batch'>('single');
     const [file, setFile] = useState('');
     const [background, setBackground] = useState('');
     const [captions, setCaptions] = useState('');
@@ -38,6 +42,15 @@ const App: React.FC = () => {
         outro: outro || undefined,
     });
 
+    if (page === 'batch') {
+        return (
+            <div>
+                <button onClick={() => setPage('single')}>Back</button>
+                <BatchPage />
+            </div>
+        );
+    }
+
     return (
         <div>
             <h1>Youtube Automation</h1>
@@ -65,16 +78,33 @@ const App: React.FC = () => {
                 <input type="text" placeholder="Captions file" value={captions} onChange={(e) => setCaptions(e.target.value)} />
             </div>
             <div>
-                <input type="text" placeholder="Intro video" value={intro} onChange={(e) => setIntro(e.target.value)} />
+                <FilePicker
+                    label="Intro"
+                    onSelect={(p) => {
+                        if (typeof p === 'string') setIntro(p);
+                        else if (Array.isArray(p) && p.length) setIntro(p[0]);
+                    }}
+                    filters={[{ name: 'Media', extensions: ['mp4', 'mov', 'mkv', 'png', 'jpg', 'jpeg'] }]}
+                />
+                {intro && <span>{intro}</span>}
             </div>
             <div>
-                <input type="text" placeholder="Outro video" value={outro} onChange={(e) => setOutro(e.target.value)} />
+                <FilePicker
+                    label="Outro"
+                    onSelect={(p) => {
+                        if (typeof p === 'string') setOutro(p);
+                        else if (Array.isArray(p) && p.length) setOutro(p[0]);
+                    }}
+                    filters={[{ name: 'Media', extensions: ['mp4', 'mov', 'mkv', 'png', 'jpg', 'jpeg'] }]}
+                />
+                {outro && <span>{outro}</span>}
             </div>
             <div>
-                <input type="text" placeholder="Font" value={font} onChange={(e) => setFont(e.target.value)} />
+                <FontSelector value={font} onChange={setFont} />
             </div>
             <div>
-                <input type="number" placeholder="Font size" value={size} onChange={(e) => setSize(parseInt(e.target.value) || 0)} />
+                <SizeSlider value={size} onChange={setSize} />
+                <span>{size}</span>
             </div>
             <div>
                 <select value={position} onChange={(e) => setPosition(e.target.value)}>
@@ -93,6 +123,7 @@ const App: React.FC = () => {
             <YouTubeAuthButton />
             <button onClick={handleGenerate}>Generate</button>
             <GenerateUploadButton params={buildParams()} />
+            <button onClick={() => setPage('batch')}>Batch Tools</button>
         </div>
     );
 };

--- a/ytapp/src/cli.ts
+++ b/ytapp/src/cli.ts
@@ -114,6 +114,40 @@ program
   });
 
 program
+  .command('generate-upload-batch')
+  .description('Generate multiple videos and upload to YouTube')
+  .argument('<files...>', 'audio files')
+  .option('-d, --output-dir <dir>', 'output directory', '.')
+  .option('--captions <srt>', 'captions file path')
+  .option('--font <font>', 'caption font')
+  .option('--size <size>', 'caption font size', (v) => parseInt(v, 10))
+  .option('--position <pos>', 'caption position (top|center|bottom)')
+  .option('-b, --background <file>', 'background image or video')
+  .option('--intro <file>', 'intro video or image')
+  .option('--outro <file>', 'outro video or image')
+  .action(async (files: string[], options: any) => {
+    try {
+      const result = await invoke('generate_batch_upload', {
+        files,
+        outputDir: options.outputDir,
+        captions: options.captions,
+        captionOptions: {
+          font: options.font,
+          size: options.size,
+          position: options.position,
+        },
+        background: options.background,
+        intro: options.intro,
+        outro: options.outro,
+      } as any);
+      console.log(result);
+    } catch (err) {
+      console.error('Error generating and uploading batch:', err);
+      process.exitCode = 1;
+    }
+  });
+
+program
   .command('batch')
   .description('Generate multiple videos')
   .argument('<files...>', 'list of audio files')

--- a/ytapp/src/components/BatchPage.tsx
+++ b/ytapp/src/components/BatchPage.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import BatchProcessor from './BatchProcessor';
+import BatchUploader from './BatchUploader';
+
+const BatchPage: React.FC = () => (
+    <div>
+        <h1>Batch Tools</h1>
+        <BatchProcessor />
+        <BatchUploader />
+    </div>
+);
+
+export default BatchPage;

--- a/ytapp/src/components/BatchProcessor.tsx
+++ b/ytapp/src/components/BatchProcessor.tsx
@@ -1,11 +1,13 @@
 import React, { useState } from 'react';
 import FilePicker from './FilePicker';
 import { generateBatchWithProgress } from '../features/batch';
+import { generateBatchUpload } from '../features/youtube';
 
 const BatchProcessor: React.FC = () => {
   const [files, setFiles] = useState<string[]>([]);
   const [progress, setProgress] = useState(0);
   const [running, setRunning] = useState(false);
+  const [uploading, setUploading] = useState(false);
 
   const handleSelect = (selected: string | string[] | null) => {
     if (Array.isArray(selected)) {
@@ -28,12 +30,20 @@ const BatchProcessor: React.FC = () => {
     setRunning(false);
   };
 
+  const startBatchUpload = async () => {
+    if (!files.length) return;
+    setUploading(true);
+    await generateBatchUpload({ files });
+    setUploading(false);
+  };
+
   return (
     <div>
       <h2>Batch Processor</h2>
       <FilePicker multiple onSelect={handleSelect} label="Select Audio Files" />
       {files.length > 0 && <p>{files.length} files selected</p>}
       <button onClick={startBatch} disabled={running || !files.length}>Start</button>
+      <button onClick={startBatchUpload} disabled={uploading || !files.length}>Generate &amp; Upload</button>
       {running && (
         <div>
           <progress value={progress} max={100} />

--- a/ytapp/src/components/BatchUploader.tsx
+++ b/ytapp/src/components/BatchUploader.tsx
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+import FilePicker from './FilePicker';
+import { uploadVideos } from '../features/youtube';
+
+const BatchUploader: React.FC = () => {
+    const [files, setFiles] = useState<string[]>([]);
+    const [progress, setProgress] = useState(0);
+    const [running, setRunning] = useState(false);
+
+    const handleSelect = (p: string | string[] | null) => {
+        if (Array.isArray(p)) setFiles(p);
+        else if (typeof p === 'string') setFiles([p]);
+    };
+
+    const startUpload = async () => {
+        if (!files.length) return;
+        setRunning(true);
+        setProgress(0);
+        const res = await uploadVideos(files);
+        console.log(res);
+        setProgress(100);
+        setRunning(false);
+    };
+
+    return (
+        <div>
+            <h3>Batch Upload</h3>
+            <FilePicker multiple onSelect={handleSelect} label="Select Videos" filters={[{ name: 'Videos', extensions: ['mp4'] }]} />
+            {files.length > 0 && <p>{files.length} files selected</p>}
+            <button onClick={startUpload} disabled={running || !files.length}>Upload</button>
+            {running && <progress value={progress} max={100} />}
+        </div>
+    );
+};
+
+export default BatchUploader;

--- a/ytapp/src/components/FontSelector.tsx
+++ b/ytapp/src/components/FontSelector.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+interface FontSelectorProps {
+    value: string;
+    onChange: (font: string) => void;
+}
+
+const fonts = ['Arial', 'Helvetica', 'Times New Roman', 'Courier New'];
+
+const FontSelector: React.FC<FontSelectorProps> = ({ value, onChange }) => {
+    return (
+        <select value={value} onChange={e => onChange(e.target.value)}>
+            <option value="">Default</option>
+            {fonts.map(f => (
+                <option key={f} value={f}>{f}</option>
+            ))}
+        </select>
+    );
+};
+
+export default FontSelector;

--- a/ytapp/src/components/SizeSlider.tsx
+++ b/ytapp/src/components/SizeSlider.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+interface SizeSliderProps {
+    value: number;
+    onChange: (v: number) => void;
+    min?: number;
+    max?: number;
+}
+
+const SizeSlider: React.FC<SizeSliderProps> = ({ value, onChange, min = 12, max = 72 }) => (
+    <input
+        type="range"
+        min={min}
+        max={max}
+        value={value}
+        onChange={e => onChange(parseInt(e.target.value, 10))}
+    />
+);
+
+export default SizeSlider;

--- a/ytapp/src/features/youtube/index.ts
+++ b/ytapp/src/features/youtube/index.ts
@@ -14,6 +14,15 @@ export async function generateUpload(params: GenerateParams): Promise<string> {
     return await invoke('generate_upload', params);
 }
 
+export interface BatchGenerateParams extends Omit<GenerateParams, 'file' | 'output'> {
+    files: string[];
+    outputDir?: string;
+}
+
+export async function generateBatchUpload(params: BatchGenerateParams): Promise<string[]> {
+    return await invoke('generate_batch_upload', params);
+}
+
 export async function signIn(): Promise<void> {
     await invoke('youtube_sign_in');
 }


### PR DESCRIPTION
## Summary
- integrate BatchProcessor and BatchUploader in a new BatchPage
- add font selector and font size slider components
- replace intro/outro inputs with file pickers
- add batch generate & upload support in Rust backend and TypeScript API
- expose new CLI command `generate-upload-batch`
- add environment checks to packaging script

## Testing
- `npm install`
- `cargo check` *(fails: glib/gobject sys libs missing)*
- `npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_68464a3126088331931df47c07eec2d5