### PR TITLE
Implement transcription and batch options

### DIFF
--- a/ytapp/src/App.tsx
+++ b/ytapp/src/App.tsx
@@ -8,6 +8,7 @@ import BatchPage from './components/BatchPage';
 import FontSelector from './components/FontSelector';
 import SizeSlider from './components/SizeSlider';
 import { languageOptions, Language } from './features/language';
+import TranscribeButton from './components/TranscribeButton';
 
 const App: React.FC = () => {
     const [page, setPage] = useState<'single' | 'batch'>('single');
@@ -20,6 +21,10 @@ const App: React.FC = () => {
     const [size, setSize] = useState(24);
     const [position, setPosition] = useState('bottom');
     const [language, setLanguage] = useState<Language>('auto');
+
+    const handleTranscriptionComplete = (srt: string) => {
+        setCaptions(srt);
+    };
 
     const handleGenerate = async () => {
         if (!file) return;
@@ -76,6 +81,7 @@ const App: React.FC = () => {
             </div>
             <div>
                 <input type="text" placeholder="Captions file" value={captions} onChange={(e) => setCaptions(e.target.value)} />
+                <TranscribeButton file={file} language={language} onComplete={handleTranscriptionComplete} />
             </div>
             <div>
                 <FilePicker

--- a/ytapp/src/cli.ts
+++ b/ytapp/src/cli.ts
@@ -38,6 +38,10 @@ async function generateAndUpload(params: GenerateParams): Promise<any> {
   return await invoke('generate_upload', params as any);
 }
 
+async function signIn(): Promise<void> {
+  await invoke('youtube_sign_in');
+}
+
 program
   .name('ytcli')
   .description('CLI for generating and uploading videos')
@@ -210,6 +214,19 @@ program
       results.forEach((res: any) => console.log(res));
     } catch (err) {
       console.error('Error uploading videos:', err);
+      process.exitCode = 1;
+    }
+  });
+
+program
+  .command('sign-in')
+  .description('Authenticate with YouTube')
+  .action(async () => {
+    try {
+      await signIn();
+      console.log('Sign-in complete');
+    } catch (err) {
+      console.error('Error during sign-in:', err);
       process.exitCode = 1;
     }
   });

--- a/ytapp/src/components/BatchOptionsForm.tsx
+++ b/ytapp/src/components/BatchOptionsForm.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import FilePicker from './FilePicker';
+import FontSelector from './FontSelector';
+import SizeSlider from './SizeSlider';
+import { BatchOptions } from '../features/batch';
+
+interface BatchOptionsFormProps {
+    value: BatchOptions;
+    onChange: (opts: BatchOptions) => void;
+}
+
+const BatchOptionsForm: React.FC<BatchOptionsFormProps> = ({ value, onChange }) => {
+    const update = (opts: Partial<BatchOptions>) => {
+        onChange({ ...value, ...opts, captionOptions: { ...value.captionOptions, ...opts.captionOptions } });
+    };
+
+    return (
+        <div>
+            <div>
+                <FilePicker
+                    label="Background"
+                    onSelect={(p) => {
+                        if (typeof p === 'string') update({ background: p });
+                        else if (Array.isArray(p) && p.length) update({ background: p[0] });
+                    }}
+                    filters={[{ name: 'Media', extensions: ['mp4', 'mov', 'mkv', 'png', 'jpg', 'jpeg'] }]}
+                />
+                {value.background && <span>{value.background}</span>}
+            </div>
+            <div>
+                <FilePicker
+                    label="Intro"
+                    onSelect={(p) => {
+                        if (typeof p === 'string') update({ intro: p });
+                        else if (Array.isArray(p) && p.length) update({ intro: p[0] });
+                    }}
+                    filters={[{ name: 'Media', extensions: ['mp4', 'mov', 'mkv', 'png', 'jpg', 'jpeg'] }]}
+                />
+                {value.intro && <span>{value.intro}</span>}
+            </div>
+            <div>
+                <FilePicker
+                    label="Outro"
+                    onSelect={(p) => {
+                        if (typeof p === 'string') update({ outro: p });
+                        else if (Array.isArray(p) && p.length) update({ outro: p[0] });
+                    }}
+                    filters={[{ name: 'Media', extensions: ['mp4', 'mov', 'mkv', 'png', 'jpg', 'jpeg'] }]}
+                />
+                {value.outro && <span>{value.outro}</span>}
+            </div>
+            <div>
+                <FontSelector value={value.captionOptions?.font || ''} onChange={(f) => update({ captionOptions: { font: f } })} />
+            </div>
+            <div>
+                <SizeSlider value={value.captionOptions?.size || 24} onChange={(s) => update({ captionOptions: { size: s } })} />
+                <span>{value.captionOptions?.size || 24}</span>
+            </div>
+            <div>
+                <select value={value.captionOptions?.position || 'bottom'} onChange={(e) => update({ captionOptions: { position: e.target.value } })}>
+                    <option value="top">Top</option>
+                    <option value="center">Center</option>
+                    <option value="bottom">Bottom</option>
+                </select>
+            </div>
+        </div>
+    );
+};
+
+export default BatchOptionsForm;

--- a/ytapp/src/components/BatchProcessor.tsx
+++ b/ytapp/src/components/BatchProcessor.tsx
@@ -1,13 +1,15 @@
 import React, { useState } from 'react';
 import FilePicker from './FilePicker';
-import { generateBatchWithProgress } from '../features/batch';
+import { generateBatchWithProgress, BatchOptions } from '../features/batch';
 import { generateBatchUpload } from '../features/youtube';
+import BatchOptionsForm from './BatchOptionsForm';
 
 const BatchProcessor: React.FC = () => {
   const [files, setFiles] = useState<string[]>([]);
   const [progress, setProgress] = useState(0);
   const [running, setRunning] = useState(false);
   const [uploading, setUploading] = useState(false);
+  const [options, setOptions] = useState<BatchOptions>({});
 
   const handleSelect = (selected: string | string[] | null) => {
     if (Array.isArray(selected)) {
@@ -23,7 +25,7 @@ const BatchProcessor: React.FC = () => {
     if (!files.length) return;
     setRunning(true);
     setProgress(0);
-    await generateBatchWithProgress(files, {}, (cur, total) => {
+    await generateBatchWithProgress(files, options, (cur, total) => {
       const pct = Math.round(((cur + 1) / total) * 100);
       setProgress(pct);
     });
@@ -33,7 +35,7 @@ const BatchProcessor: React.FC = () => {
   const startBatchUpload = async () => {
     if (!files.length) return;
     setUploading(true);
-    await generateBatchUpload({ files });
+    await generateBatchUpload({ files, ...options });
     setUploading(false);
   };
 
@@ -42,6 +44,7 @@ const BatchProcessor: React.FC = () => {
       <h2>Batch Processor</h2>
       <FilePicker multiple onSelect={handleSelect} label="Select Audio Files" />
       {files.length > 0 && <p>{files.length} files selected</p>}
+      <BatchOptionsForm value={options} onChange={setOptions} />
       <button onClick={startBatch} disabled={running || !files.length}>Start</button>
       <button onClick={startBatchUpload} disabled={uploading || !files.length}>Generate &amp; Upload</button>
       {running && (

--- a/ytapp/src/components/BatchUploader.tsx
+++ b/ytapp/src/components/BatchUploader.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from 'react';
 import FilePicker from './FilePicker';
-import { uploadVideos } from '../features/youtube';
+import { uploadVideo } from '../features/youtube';
 
 const BatchUploader: React.FC = () => {
     const [files, setFiles] = useState<string[]>([]);
-    const [progress, setProgress] = useState(0);
+    const [progressMap, setProgressMap] = useState<Record<string, number>>({});
     const [running, setRunning] = useState(false);
 
     const handleSelect = (p: string | string[] | null) => {
@@ -15,10 +15,15 @@ const BatchUploader: React.FC = () => {
     const startUpload = async () => {
         if (!files.length) return;
         setRunning(true);
-        setProgress(0);
-        const res = await uploadVideos(files);
-        console.log(res);
-        setProgress(100);
+        const prog: Record<string, number> = {};
+        setProgressMap({});
+        for (const file of files) {
+            prog[file] = 0;
+            setProgressMap({ ...prog });
+            await uploadVideo(file);
+            prog[file] = 100;
+            setProgressMap({ ...prog });
+        }
         setRunning(false);
     };
 
@@ -28,7 +33,13 @@ const BatchUploader: React.FC = () => {
             <FilePicker multiple onSelect={handleSelect} label="Select Videos" filters={[{ name: 'Videos', extensions: ['mp4'] }]} />
             {files.length > 0 && <p>{files.length} files selected</p>}
             <button onClick={startUpload} disabled={running || !files.length}>Upload</button>
-            {running && <progress value={progress} max={100} />}
+            {files.map(f => (
+                <div key={f}>
+                    <span>{f}</span>
+                    {running && <progress value={progressMap[f] || 0} max={100} />}
+                    {!running && progressMap[f] === 100 && <span>Done</span>}
+                </div>
+            ))}
         </div>
     );
 };

--- a/ytapp/src/components/TranscribeButton.tsx
+++ b/ytapp/src/components/TranscribeButton.tsx
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+import { transcribeAudio } from '../features/transcription';
+import { Language } from '../features/language';
+
+interface TranscribeButtonProps {
+    file: string;
+    language: Language;
+    onComplete: (srtPath: string) => void;
+}
+
+const TranscribeButton: React.FC<TranscribeButtonProps> = ({ file, language, onComplete }) => {
+    const [running, setRunning] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const handleClick = async () => {
+        if (!file) return;
+        setRunning(true);
+        setError(null);
+        try {
+            const result = await transcribeAudio({ file, language });
+            onComplete(result);
+        } catch (err: any) {
+            setError(String(err));
+        }
+        setRunning(false);
+    };
+
+    return (
+        <div>
+            <button onClick={handleClick} disabled={running || !file}>
+                {running ? 'Transcribing...' : 'Transcribe'}
+            </button>
+            {error && <span>{error}</span>}
+        </div>
+    );
+};
+
+export default TranscribeButton;


### PR DESCRIPTION
## Summary
- add a button for transcribing audio before generating videos
- add configurable batch options form
- show per-file progress for batch uploads
- expose YouTube sign-in command in CLI

## Testing
- `cd ytapp && npm install`
- `cd src-tauri && cargo check` *(fails: glib-2.0 missing)*
- `cd .. && npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_68464eec16008331ba81bcf8ad083c0f