### PR TITLE
UI clean up and design guide

### DIFF
--- a/design.md
+++ b/design.md
@@ -1,0 +1,17 @@
+# Design Guide
+
+This project follows a minimalist approach inspired by the principle **"Less but better"**. Interfaces should focus on clarity and essential functions.
+
+## Layout
+- Use CSS grid or flexbox to create simple, well-spaced layouts.
+- Provide generous spacing between controls to reduce visual clutter.
+
+## Colors
+- Prefer a neutral palette: light backgrounds (`#f5f5f5`) and dark text (`#333`).
+- Avoid excessive decoration and keep iconography minimal.
+
+## Components
+- Only present controls that are necessary for the task.
+- Display selected file paths as plain text instead of editable inputs.
+
+Following these guidelines keeps the UI clear and purposeful.

--- a/readme.md
+++ b/readme.md
@@ -147,6 +147,10 @@ cargo check          # run inside ytapp/src-tauri
 npx ts-node src/cli.ts --help
 ```
 
+### Design Guidelines
+
+See [design.md](design.md) for the UI style guide based on the principle "Less but better".
+
 Finally, start the Tauri application:
 
 ```bash

--- a/ytapp/src/App.tsx
+++ b/ytapp/src/App.tsx
@@ -1,8 +1,7 @@
 import React, { useState } from 'react';
 import { generateVideo } from './features/processing';
 import YouTubeAuthButton from './components/YouTubeAuthButton';
-import GenerateUploadButton from './components/GenerateUploadButton';
-import { GenerateParams } from './features/youtube';
+import { generateUpload, GenerateParams } from './features/youtube';
 import FilePicker from './components/FilePicker';
 import BatchPage from './components/BatchPage';
 import FontSelector from './components/FontSelector';
@@ -47,27 +46,33 @@ const App: React.FC = () => {
         outro: outro || undefined,
     });
 
+    const handleGenerateUpload = async () => {
+        if (!file) return;
+        await generateUpload(buildParams());
+    };
+
     if (page === 'batch') {
         return (
-            <div>
-                <button onClick={() => setPage('single')}>Back</button>
+            <div className="app">
+                <div className="row">
+                    <button onClick={() => setPage('single')}>Back</button>
+                </div>
                 <BatchPage />
             </div>
         );
     }
 
     return (
-        <div>
+        <div className="app">
             <h1>Youtube Automation</h1>
-            <div>
-                <input type="text" placeholder="Audio file" value={file} onChange={(e) => setFile(e.target.value)} />
-                <FilePicker label="Browse" onSelect={(p) => {
+            <div className="row">
+                <FilePicker label="Select Audio" onSelect={(p) => {
                     if (typeof p === 'string') setFile(p);
                     else if (Array.isArray(p) && p.length) setFile(p[0]);
                 }} />
+                {file && <span>{file}</span>}
             </div>
-            <div>
-                <input type="text" placeholder="Background" value={background} onChange={(e) => setBackground(e.target.value)} />
+            <div className="row">
                 <FilePicker
                     label="Background"
                     onSelect={(p) => {
@@ -78,12 +83,13 @@ const App: React.FC = () => {
                         { name: 'Media', extensions: ['mp4', 'mov', 'mkv', 'png', 'jpg', 'jpeg'] },
                     ]}
                 />
+                {background && <span>{background}</span>}
             </div>
-            <div>
-                <input type="text" placeholder="Captions file" value={captions} onChange={(e) => setCaptions(e.target.value)} />
+            <div className="row">
                 <TranscribeButton file={file} language={language} onComplete={handleTranscriptionComplete} />
+                {captions && <span>{captions}</span>}
             </div>
-            <div>
+            <div className="row">
                 <FilePicker
                     label="Intro"
                     onSelect={(p) => {
@@ -94,7 +100,7 @@ const App: React.FC = () => {
                 />
                 {intro && <span>{intro}</span>}
             </div>
-            <div>
+            <div className="row">
                 <FilePicker
                     label="Outro"
                     onSelect={(p) => {
@@ -105,31 +111,33 @@ const App: React.FC = () => {
                 />
                 {outro && <span>{outro}</span>}
             </div>
-            <div>
+            <div className="row">
                 <FontSelector value={font} onChange={setFont} />
             </div>
-            <div>
+            <div className="row">
                 <SizeSlider value={size} onChange={setSize} />
                 <span>{size}</span>
             </div>
-            <div>
+            <div className="row">
                 <select value={position} onChange={(e) => setPosition(e.target.value)}>
                     <option value="top">Top</option>
                     <option value="center">Center</option>
                     <option value="bottom">Bottom</option>
                 </select>
             </div>
-            <div>
+            <div className="row">
                 <select value={language} onChange={(e) => setLanguage(e.target.value as Language)}>
                     {languageOptions.map(opt => (
                         <option key={opt.value} value={opt.value}>{opt.label}</option>
                     ))}
                 </select>
             </div>
-            <YouTubeAuthButton />
-            <button onClick={handleGenerate}>Generate</button>
-            <GenerateUploadButton params={buildParams()} />
-            <button onClick={() => setPage('batch')}>Batch Tools</button>
+            <div className="row">
+                <YouTubeAuthButton />
+                <button onClick={handleGenerate}>Generate</button>
+                <button onClick={handleGenerateUpload}>Generate &amp; Upload</button>
+                <button onClick={() => setPage('batch')}>Batch Tools</button>
+            </div>
         </div>
     );
 };

--- a/ytapp/src/components/FilePicker.tsx
+++ b/ytapp/src/components/FilePicker.tsx
@@ -13,7 +13,7 @@ interface FilePickerProps {
   filters?: FileFilter[];
 }
 
-const FilePicker: React.FC<FilePickerProps> = ({ multiple, onSelect, label }) => {
+const FilePicker: React.FC<FilePickerProps> = ({ multiple, onSelect, label, filters }) => {
   const handleClick = async () => {
     const defaultFilters: FileFilter[] = [
       { name: 'Audio', extensions: ['mp3', 'wav', 'm4a', 'flac', 'aac'] },

--- a/ytapp/src/main.tsx
+++ b/ytapp/src/main.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
+import './style.css';
 
 const container = document.getElementById('root');
 if (container) {

--- a/ytapp/src/style.css
+++ b/ytapp/src/style.css
@@ -1,0 +1,24 @@
+body {
+  margin: 0;
+  font-family: sans-serif;
+  background-color: #f5f5f5;
+  color: #333;
+}
+
+.app {
+  display: grid;
+  gap: 1rem;
+  padding: 2rem;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.row {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+button {
+  padding: 0.5rem 1rem;
+}


### PR DESCRIPTION
## Summary
- streamline single-video UI with simple grid layout
- apply neutral color scheme
- fix `FilePicker` filters prop
- document minimalist design principles
- mention design guide in README

## Testing
- `npm install` within `ytapp`
- `cargo check` *(fails: glib-2.0 missing)*
- `npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_68465e5065e88331a9671da22ca50e2f