### PR TITLE
Add configurable settings page

### DIFF
--- a/ytapp/public/locales/en/translation.json
+++ b/ytapp/public/locales/en/translation.json
@@ -27,5 +27,7 @@
   "signed_in": "Signed in to YouTube",
   "checking": "Checking...",
   "default": "Default",
-  "toggle_theme": "Toggle Theme"
+  "toggle_theme": "Toggle Theme",
+  "settings": "Settings",
+  "save": "Save"
 }

--- a/ytapp/public/locales/hi/translation.json
+++ b/ytapp/public/locales/hi/translation.json
@@ -27,5 +27,7 @@
   "signed_in": "YouTube में साइन इन",
   "checking": "जांच हो रही है...",
   "default": "डिफ़ॉल्ट",
-  "toggle_theme": "थीम बदलें"
+  "toggle_theme": "थीम बदलें",
+  "settings": "Settings",
+  "save": "Save"
 }

--- a/ytapp/public/locales/ne/translation.json
+++ b/ytapp/public/locales/ne/translation.json
@@ -27,5 +27,7 @@
   "signed_in": "युट्युबमा साइन इन भएको",
   "checking": "जाँच हुँदै...",
   "default": "पूर्वनिर्धारित",
-  "toggle_theme": "थिम बदल्नुहोस्"
+  "toggle_theme": "थिम बदल्नुहोस्",
+  "settings": "Settings",
+  "save": "Save"
 }

--- a/ytapp/src/App.tsx
+++ b/ytapp/src/App.tsx
@@ -5,14 +5,16 @@ import YouTubeAuthButton from './components/YouTubeAuthButton';
 import { generateUpload, GenerateParams } from './features/youtube';
 import FilePicker from './components/FilePicker';
 import BatchPage from './components/BatchPage';
+import SettingsPage from './components/SettingsPage';
 import FontSelector from './components/FontSelector';
 import SizeSlider from './components/SizeSlider';
 import { languageOptions, Language } from './features/language';
 import TranscribeButton from './components/TranscribeButton';
+import { loadSettings } from './features/settings';
 
 const App: React.FC = () => {
     const { t, i18n } = useTranslation();
-    const [page, setPage] = useState<'single' | 'batch'>('single');
+    const [page, setPage] = useState<'single' | 'batch' | 'settings'>('single');
     const [file, setFile] = useState('');
     const [background, setBackground] = useState('');
     const [captions, setCaptions] = useState('');
@@ -25,6 +27,16 @@ const App: React.FC = () => {
     const [theme, setTheme] = useState<'light' | 'dark'>(() =>
         localStorage.getItem('theme') === 'dark' ? 'dark' : 'light'
     );
+
+    useEffect(() => {
+        loadSettings().then(s => {
+            if (s.background) setBackground(s.background);
+            if (s.intro) setIntro(s.intro);
+            if (s.outro) setOutro(s.outro);
+            if (s.captionFont) setFont(s.captionFont);
+            if (s.captionSize) setSize(s.captionSize);
+        });
+    }, []);
 
     useEffect(() => {
         document.documentElement.setAttribute('data-theme', theme);
@@ -70,6 +82,17 @@ const App: React.FC = () => {
                     <button onClick={() => setPage('single')}>{t('back')}</button>
                 </div>
                 <BatchPage />
+            </div>
+        );
+    }
+
+    if (page === 'settings') {
+        return (
+            <div className="app">
+                <div className="row">
+                    <button onClick={() => setPage('single')}>{t('back')}</button>
+                </div>
+                <SettingsPage />
             </div>
         );
     }
@@ -160,6 +183,7 @@ const App: React.FC = () => {
                 <button onClick={handleGenerate}>{t('generate')}</button>
                 <button onClick={handleGenerateUpload}>{t('generate_upload')}</button>
                 <button onClick={() => setPage('batch')}>{t('batch_tools')}</button>
+                <button onClick={() => setPage('settings')}>{t('settings')}</button>
             </div>
         </div>
     );

--- a/ytapp/src/components/SettingsPage.tsx
+++ b/ytapp/src/components/SettingsPage.tsx
@@ -1,0 +1,84 @@
+import React, { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import FilePicker from './FilePicker';
+import FontSelector from './FontSelector';
+import SizeSlider from './SizeSlider';
+import { loadSettings, saveSettings } from '../features/settings';
+
+const SettingsPage: React.FC = () => {
+    const { t } = useTranslation();
+    const [background, setBackground] = useState('');
+    const [intro, setIntro] = useState('');
+    const [outro, setOutro] = useState('');
+    const [font, setFont] = useState('');
+    const [size, setSize] = useState(24);
+
+    useEffect(() => {
+        loadSettings().then(s => {
+            setBackground(s.background || '');
+            setIntro(s.intro || '');
+            setOutro(s.outro || '');
+            setFont(s.captionFont || '');
+            setSize(s.captionSize || 24);
+        });
+    }, []);
+
+    const handleSave = async () => {
+        await saveSettings({
+            background: background || undefined,
+            intro: intro || undefined,
+            outro: outro || undefined,
+            captionFont: font || undefined,
+            captionSize: size,
+        });
+    };
+
+    return (
+        <div>
+            <h1>{t('settings')}</h1>
+            <div>
+                <FilePicker
+                    label={t('background')}
+                    onSelect={p => {
+                        if (typeof p === 'string') setBackground(p);
+                        else if (Array.isArray(p) && p.length) setBackground(p[0]);
+                    }}
+                    filters={[{ name: 'Media', extensions: ['mp4', 'mov', 'mkv', 'png', 'jpg', 'jpeg'] }]}
+                />
+                {background && <span>{background}</span>}
+            </div>
+            <div>
+                <FilePicker
+                    label={t('intro')}
+                    onSelect={p => {
+                        if (typeof p === 'string') setIntro(p);
+                        else if (Array.isArray(p) && p.length) setIntro(p[0]);
+                    }}
+                    filters={[{ name: 'Media', extensions: ['mp4', 'mov', 'mkv', 'png', 'jpg', 'jpeg'] }]}
+                />
+                {intro && <span>{intro}</span>}
+            </div>
+            <div>
+                <FilePicker
+                    label={t('outro')}
+                    onSelect={p => {
+                        if (typeof p === 'string') setOutro(p);
+                        else if (Array.isArray(p) && p.length) setOutro(p[0]);
+                    }}
+                    filters={[{ name: 'Media', extensions: ['mp4', 'mov', 'mkv', 'png', 'jpg', 'jpeg'] }]}
+                />
+                {outro && <span>{outro}</span>}
+            </div>
+            <div>
+                <FontSelector value={font} onChange={setFont} />
+            </div>
+            <div>
+                <SizeSlider value={size} onChange={setSize} />
+                <span>{size}</span>
+            </div>
+            <button onClick={handleSave}>{t('save')}</button>
+        </div>
+    );
+};
+
+export default SettingsPage;

--- a/ytapp/src/features/settings/index.ts
+++ b/ytapp/src/features/settings/index.ts
@@ -1,0 +1,17 @@
+import { invoke } from '@tauri-apps/api/core';
+
+export interface Settings {
+    intro?: string;
+    outro?: string;
+    background?: string;
+    captionFont?: string;
+    captionSize?: number;
+}
+
+export async function loadSettings(): Promise<Settings> {
+    return await invoke('load_settings');
+}
+
+export async function saveSettings(settings: Settings): Promise<void> {
+    await invoke('save_settings', { settings });
+}


### PR DESCRIPTION
## Summary
- add SettingsPage component and hook it into the main App
- store/load defaults using new Tauri commands
- expose frontend utilities for settings persistence
- update i18n files with Settings strings

## Testing
- `npm install`
- `cargo check` *(fails: tauri configuration missing and other errors)*
- `npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_684761c41f7083318b4e423507e29f9a