### PR TITLE
Add startup dependency checks

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -99,6 +99,8 @@
   * Mac `.dmg` installer
   * Linux `.AppImage`
 * Bundle Whisper model downloader on first launch
+* Checks for FFmpeg and the Whisper model at startup. Missing dependencies
+  trigger a dialog explaining how to install them.
 
 ---
 

--- a/ytapp/src/App.tsx
+++ b/ytapp/src/App.tsx
@@ -11,6 +11,7 @@ import SizeSlider from './components/SizeSlider';
 import { languageOptions, Language } from './features/language';
 import TranscribeButton from './components/TranscribeButton';
 import { loadSettings } from './features/settings';
+import { checkDependencies } from './features/dependencies';
 
 const App: React.FC = () => {
     const { t, i18n } = useTranslation();
@@ -27,6 +28,10 @@ const App: React.FC = () => {
     const [theme, setTheme] = useState<'light' | 'dark'>(() =>
         localStorage.getItem('theme') === 'dark' ? 'dark' : 'light'
     );
+
+    useEffect(() => {
+        checkDependencies();
+    }, []);
 
     useEffect(() => {
         loadSettings().then(s => {

--- a/ytapp/src/features/dependencies/index.ts
+++ b/ytapp/src/features/dependencies/index.ts
@@ -1,0 +1,9 @@
+import { invoke } from '@tauri-apps/api/core';
+
+export async function checkDependencies(): Promise<void> {
+    try {
+        await invoke('verify_dependencies');
+    } catch {
+        // errors are already shown via dialog
+    }
+}


### PR DESCRIPTION
## Summary
- verify FFmpeg and Whisper model availability in Tauri backend
- call the dependency check when the React app launches
- document new dependency check behavior

## Testing
- `npm install`
- `cargo check` *(fails: tauri.conf.json missing, token store type errors)*
- `npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_68476631962c83318617df1319684e72