### PR TITLE
Add progress events and UI updates

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -86,6 +86,7 @@
 * YouTube sign-in button + status
 * Generate video button
 * Generate & upload to YouTube button
+* Generation progress bar
 * Batch process progress UI
 
 ---


### PR DESCRIPTION
## Summary
- emit `generate_progress` events in Rust when ffmpeg runs
- listen for progress updates in TS processing API
- show generation progress bar in the React UI
- document generation progress in the readme

## Testing
- `npm install` *(passes)*
- `cargo check` *(fails: missing system libraries and compilation errors)*
- `npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_6847720f04c08331b25ccf3a89a0292a