### PR TITLE
Support vertical video resolutions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,7 @@
   * Optional Outro (user-provided video or image)
   * Output: Final video (H.264 MP4)
   * Configurable resolution via `--width`/`--height` or UI dropdown
+  * Supports vertical short-form formats (720x1280 and 1080x1920)
 
 ---
 

--- a/ytapp/src-tauri/src/main.rs
+++ b/ytapp/src-tauri/src/main.rs
@@ -140,13 +140,11 @@ fn convert_media(path: &str, duration: Option<f64>, width: u32, height: u32) -> 
     if status.success() { Ok(out) } else { Err("ffmpeg failed".into()) }
 }
 
-fn build_main_section(window: Option<&Window>, params: &GenerateParams, duration: f64) -> Result<PathBuf, String> {
+fn build_main_section(window: Option<&Window>, params: &GenerateParams, duration: f64, width: u32, height: u32) -> Result<PathBuf, String> {
     let out = temp_file("main");
     let mut cmd = Command::new("ffmpeg");
     cmd.arg("-y");
 
-    let width = params.width.unwrap_or(1280);
-    let height = params.height.unwrap_or(720);
 
     match params.background.as_deref() {
         Some(bg) if is_image(bg) => {
@@ -211,7 +209,7 @@ fn generate_video(window: Window, params: GenerateParams) -> Result<String, Stri
 
     let duration = audio_duration(&params.file)?;
     let _ = window.emit("generate_progress", 0f64);
-    let main = build_main_section(Some(&window), &params, duration)?;
+    let main = build_main_section(Some(&window), &params, duration, width, height)?;
 
     let mut segments = Vec::new();
     if let Some(ref intro) = params.intro {

--- a/ytapp/src/App.tsx
+++ b/ytapp/src/App.tsx
@@ -231,6 +231,8 @@ const App: React.FC = () => {
                     <option value="640x360">640x360</option>
                     <option value="1280x720">1280x720</option>
                     <option value="1920x1080">1920x1080</option>
+                    <option value="720x1280">720x1280</option>
+                    <option value="1080x1920">1080x1920</option>
                 </select>
             </div>
             <div className="row">

--- a/ytapp/src/components/BatchOptionsForm.tsx
+++ b/ytapp/src/components/BatchOptionsForm.tsx
@@ -77,6 +77,8 @@ const BatchOptionsForm: React.FC<BatchOptionsFormProps> = ({ value, onChange }) 
                     <option value="640x360">640x360</option>
                     <option value="1280x720">1280x720</option>
                     <option value="1920x1080">1920x1080</option>
+                    <option value="720x1280">720x1280</option>
+                    <option value="1080x1920">1080x1920</option>
                 </select>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- add 720x1280 and 1080x1920 options in UI forms
- pass width/height explicitly to `build_main_section`
- document short-form vertical video support

## Testing
- `npm install`
- `cargo check` *(fails: missing tauri config / unresolved crates)*
- `npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_684797da10a08331a3cb4b22ac4835ff