### PR TITLE
Add auto dependency install prompt

### DIFF
--- a/ytapp/src-tauri/src/main.rs
+++ b/ytapp/src-tauri/src/main.rs
@@ -466,10 +466,28 @@ fn verify_dependencies(app: tauri::AppHandle) -> Result<(), String> {
     Ok(())
 }
 
+#[command]
+fn install_tauri_deps() -> Result<(), String> {
+    let script = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../scripts/install_tauri_deps.sh");
+    if !script.exists() {
+        return Err("install script not found".into());
+    }
+    let status = Command::new("bash")
+        .arg(script)
+        .status()
+        .map_err(|e| e.to_string())?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("script exited with status {:?}", status.code()))
+    }
+}
+
 fn main() {
     ensure_whisper_model();
     tauri::Builder::default()
-        .invoke_handler(tauri::generate_handler![generate_video, upload_video, upload_videos, transcribe_audio, generate_upload, generate_batch_upload, youtube_sign_in, youtube_is_signed_in, load_settings, save_settings, verify_dependencies])
+        .invoke_handler(tauri::generate_handler![generate_video, upload_video, upload_videos, transcribe_audio, generate_upload, generate_batch_upload, youtube_sign_in, youtube_is_signed_in, load_settings, save_settings, verify_dependencies, install_tauri_deps])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/ytapp/src/App.tsx
+++ b/ytapp/src/App.tsx
@@ -15,7 +15,6 @@ import SizeSlider from './components/SizeSlider';
 import { languageOptions, Language } from './features/language';
 import TranscribeButton from './components/TranscribeButton';
 import { loadSettings } from './features/settings';
-import { checkDependencies } from './features/dependencies';
 import Modal from './components/Modal';
 
 const App: React.FC = () => {
@@ -40,9 +39,6 @@ const App: React.FC = () => {
     const [outputs, setOutputs] = useState<string[]>([]);
     const [preview, setPreview] = useState('');
 
-    useEffect(() => {
-        checkDependencies();
-    }, []);
 
     useEffect(() => {
         loadSettings().then(s => {

--- a/ytapp/src/features/dependencies/index.ts
+++ b/ytapp/src/features/dependencies/index.ts
@@ -1,9 +1,16 @@
 import { invoke } from '@tauri-apps/api/core';
 
 export async function checkDependencies(): Promise<void> {
-    try {
+  try {
+    await invoke('verify_dependencies');
+  } catch {
+    if (window.confirm('Required components are missing. Install now?')) {
+      try {
+        await invoke('install_tauri_deps');
         await invoke('verify_dependencies');
-    } catch {
-        // errors are already shown via dialog
+      } catch {
+        window.alert('Failed to install dependencies. Please run scripts/install_tauri_deps.sh manually.');
+      }
     }
+  }
 }

--- a/ytapp/src/main.tsx
+++ b/ytapp/src/main.tsx
@@ -4,9 +4,12 @@ import App from './App';
 import './style.css';
 import './theme.css';
 import './i18n';
+import { checkDependencies } from './features/dependencies';
 
 const container = document.getElementById('root');
 if (container) {
     const root = createRoot(container);
-    root.render(<App />);
+    checkDependencies().finally(() => {
+        root.render(<App />);
+    });
 }


### PR DESCRIPTION
## Summary
- expose a new Tauri command `install_tauri_deps` to run the `scripts/install_tauri_deps.sh` script
- show an Install dialog from the dependency check routine
- trigger dependency check during startup from `main.tsx`
- remove duplicate check from `App.tsx`

## Testing
- `npm install`
- `cargo check` *(fails: glib-2.0 not found)*
- `npx ts-node ytapp/src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_684797db737c83318049c81d7448a0e9