### PR TITLE
Add multi-language transcription support

### DIFF
--- a/ytapp/src/App.tsx
+++ b/ytapp/src/App.tsx
@@ -26,6 +26,7 @@ const App: React.FC = () => {
     const [captions, setCaptions] = useState('');
     const [intro, setIntro] = useState('');
     const [outro, setOutro] = useState('');
+    const [translations, setTranslations] = useState<string[]>([]);
     const [font, setFont] = useState('');
     const [size, setSize] = useState(24);
     const [position, setPosition] = useState('bottom');
@@ -61,8 +62,8 @@ const App: React.FC = () => {
 
     const toggleTheme = () => setTheme(theme === 'light' ? 'dark' : 'light');
 
-    const handleTranscriptionComplete = (srt: string) => {
-        setCaptions(srt);
+    const handleTranscriptionComplete = (srts: string[]) => {
+        if (srts.length) setCaptions(srts[0]);
     };
 
     const handleGenerate = async () => {
@@ -177,7 +178,12 @@ const App: React.FC = () => {
                 {background && <span>{background}</span>}
             </div>
             <div className="row">
-                <TranscribeButton file={file} language={language} onComplete={handleTranscriptionComplete} />
+                <TranscribeButton
+                    file={file}
+                    language={language}
+                    targets={translations}
+                    onComplete={handleTranscriptionComplete}
+                />
                 {captions && <span>{captions}</span>}
             </div>
             <div className="row">
@@ -239,6 +245,23 @@ const App: React.FC = () => {
                         <option key={opt.value} value={opt.value}>{opt.label}</option>
                     ))}
                 </select>
+            </div>
+            <div className="row">
+                {languageOptions.filter(opt => opt.value !== 'auto').map(opt => (
+                    <label key={opt.value} style={{ marginRight: '0.5em' }}>
+                        <input
+                            type="checkbox"
+                            value={opt.value}
+                            checked={translations.includes(opt.value)}
+                            onChange={() => {
+                                setTranslations(ts => ts.includes(opt.value)
+                                    ? ts.filter(t => t !== opt.value)
+                                    : [...ts, opt.value]);
+                            }}
+                        />
+                        {opt.label}
+                    </label>
+                ))}
             </div>
             <div className="row">
                 <YouTubeAuthButton />

--- a/ytapp/src/components/TranscribeButton.tsx
+++ b/ytapp/src/components/TranscribeButton.tsx
@@ -6,10 +6,14 @@ import { Language } from '../features/language';
 interface TranscribeButtonProps {
     file: string;
     language: Language;
-    onComplete: (srtPath: string) => void;
+    /**
+     * Languages to translate the generated captions into.
+     */
+    targets: string[];
+    onComplete: (srtPaths: string[]) => void;
 }
 
-const TranscribeButton: React.FC<TranscribeButtonProps> = ({ file, language, onComplete }) => {
+const TranscribeButton: React.FC<TranscribeButtonProps> = ({ file, language, targets, onComplete }) => {
     const { t } = useTranslation();
     const [running, setRunning] = useState(false);
     const [error, setError] = useState<string | null>(null);
@@ -19,7 +23,7 @@ const TranscribeButton: React.FC<TranscribeButtonProps> = ({ file, language, onC
         setRunning(true);
         setError(null);
         try {
-            const result = await transcribeAudio({ file, language });
+            const result = await transcribeAudio({ file, language, translate: targets });
             onComplete(result);
         } catch (err: any) {
             setError(String(err));


### PR DESCRIPTION
## Summary
- support multiple `translate` codes when transcribing audio
- update CLI and UI to allow selecting multiple translation targets
- produce separate SRT files for each language

## Testing
- `npm install`
- `cargo check` *(fails: gobject/glib not found)*
- `npx ts-node src/cli.ts --help`
- `npx ts-node src/cli.ts transcribe --help`


------
https://chatgpt.com/codex/tasks/task_e_68479828a43c8331be3331cac2ed1b9c