### PR TITLE
Add video metadata options

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -168,4 +168,20 @@ Finally, start the Tauri application:
 npm run start
 ```
 
+### CLI Usage
+
+Generate and schedule an upload:
+
+```bash
+npx ts-node src/cli.ts generate-upload input.wav --title "My Video" \
+  --description "Demo" --tags tag1,tag2 \
+  --publish-at "2024-07-01T12:00:00Z"
+```
+
+Upload an existing video with metadata:
+
+```bash
+npx ts-node src/cli.ts upload video.mp4 --title "My Video"
+```
+
 

--- a/ytapp/public/locales/ar/translation.json
+++ b/ytapp/public/locales/ar/translation.json
@@ -32,5 +32,9 @@
   "settings": "\u0627\u0644\u0625\u0639\u062f\u0627\u062f\u0627\u062a",
   "save": "\u062d\u0641\u0638",
   "preview": "\u0645\u0639\u0627\u064a\u0646\u0629",
-  "advanced_settings": "\u0625\u0639\u062f\u0627\u062f\u0627\u062a \u0645\u062a\u0642\u062f\u0645\u0629"
+  "advanced_settings": "\u0625\u0639\u062f\u0627\u062f\u0627\u062a \u0645\u062a\u0642\u062f\u0645\u0629",
+  "video_title": "Title",
+  "description": "Description",
+  "tags": "Tags",
+  "publish_date": "Publish Date"
 }

--- a/ytapp/public/locales/en/translation.json
+++ b/ytapp/public/locales/en/translation.json
@@ -32,5 +32,9 @@
   "settings": "Settings",
   "save": "Save",
   "preview": "Preview",
-  "advanced_settings": "Advanced Settings"
+  "advanced_settings": "Advanced Settings",
+  "video_title": "Title",
+  "description": "Description",
+  "tags": "Tags",
+  "publish_date": "Publish Date"
 }

--- a/ytapp/public/locales/es/translation.json
+++ b/ytapp/public/locales/es/translation.json
@@ -32,5 +32,9 @@
   "settings": "Ajustes",
   "save": "Guardar",
   "preview": "Vista previa",
-  "advanced_settings": "Configuraci\u00f3n avanzada"
+  "advanced_settings": "Configuraci\u00f3n avanzada",
+  "video_title": "Title",
+  "description": "Description",
+  "tags": "Tags",
+  "publish_date": "Publish Date"
 }

--- a/ytapp/public/locales/fr/translation.json
+++ b/ytapp/public/locales/fr/translation.json
@@ -32,5 +32,9 @@
   "settings": "Paramètres",
   "save": "Sauvegarder",
   "preview": "Aperçu",
-  "advanced_settings": "Paramètres avancés"
+  "advanced_settings": "Paramètres avancés",
+  "video_title": "Title",
+  "description": "Description",
+  "tags": "Tags",
+  "publish_date": "Publish Date"
 }

--- a/ytapp/public/locales/hi/translation.json
+++ b/ytapp/public/locales/hi/translation.json
@@ -32,5 +32,9 @@
   "settings": "Settings",
   "save": "Save",
   "preview": "पूर्वावलोकन",
-  "advanced_settings": "उन्नत सेटिंग्स"
+  "advanced_settings": "उन्नत सेटिंग्स",
+  "video_title": "Title",
+  "description": "Description",
+  "tags": "Tags",
+  "publish_date": "Publish Date"
 }

--- a/ytapp/public/locales/ne/translation.json
+++ b/ytapp/public/locales/ne/translation.json
@@ -32,5 +32,9 @@
   "settings": "Settings",
   "save": "Save",
   "preview": "पूर्वावलोकन",
-  "advanced_settings": "उन्नत सेटिंग"
+  "advanced_settings": "उन्नत सेटिंग",
+  "video_title": "Title",
+  "description": "Description",
+  "tags": "Tags",
+  "publish_date": "Publish Date"
 }

--- a/ytapp/public/locales/zh/translation.json
+++ b/ytapp/public/locales/zh/translation.json
@@ -32,5 +32,9 @@
   "settings": "\u8bbe\u7f6e",
   "save": "\u4fdd\u5b58",
   "preview": "\u9884\u89c8",
-  "advanced_settings": "\u9ad8\u7ea7\u8bbe\u7f6e"
+  "advanced_settings": "\u9ad8\u7ea7\u8bbe\u7f6e",
+  "video_title": "Title",
+  "description": "Description",
+  "tags": "Tags",
+  "publish_date": "Publish Date"
 }

--- a/ytapp/src-tauri/Cargo.toml
+++ b/ytapp/src-tauri/Cargo.toml
@@ -16,3 +16,4 @@ yup-oauth2 = "11"
 chacha20poly1305 = { version = "0.10", features = ["std"] }
 rand_core = "0.6"
 async-trait = "0.1"
+chrono = { version = "0.4", features = ["serde"] }

--- a/ytapp/src-tauri/src/main.rs
+++ b/ytapp/src-tauri/src/main.rs
@@ -15,6 +15,7 @@ use yup_oauth2::{InstalledFlowAuthenticator, InstalledFlowReturnMethod};
 use yup_oauth2::authenticator::Authenticator;
 use hyper_rustls::HttpsConnectorBuilder;
 use hyper_util::{client::legacy::Client, rt::TokioExecutor};
+use chrono::prelude::*;
 mod language;
 mod token_store;
 use token_store::EncryptedTokenStorage;
@@ -27,7 +28,7 @@ struct CaptionOptions {
     position: Option<String>,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 struct GenerateParams {
     file: String,
     output: Option<String>,
@@ -38,6 +39,18 @@ struct GenerateParams {
     outro: Option<String>,
     width: Option<u32>,
     height: Option<u32>,
+    title: Option<String>,
+    description: Option<String>,
+    tags: Option<Vec<String>>,
+    publish_at: Option<String>,
+}
+
+#[derive(Deserialize, Clone, Default)]
+struct UploadOptions {
+    title: Option<String>,
+    description: Option<String>,
+    tags: Option<Vec<String>>,
+    publish_at: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Default, Clone)]
@@ -253,7 +266,7 @@ fn generate_video(window: Window, params: GenerateParams) -> Result<String, Stri
     Ok(output_path)
 }
 
-async fn upload_video_impl(file: String) -> Result<String, String> {
+async fn upload_video_impl(file: String, opts: UploadOptions) -> Result<String, String> {
     let auth = build_authenticator().await?;
 
     let client = Client::builder(TokioExecutor::new())
@@ -272,13 +285,20 @@ async fn upload_video_impl(file: String) -> Result<String, String> {
         .and_then(|n| n.to_str())
         .unwrap_or("upload");
 
-    let video = Video {
-        snippet: Some(google_youtube3::api::VideoSnippet {
-            title: Some(file_name.to_string()),
-            ..Default::default()
-        }),
+    let mut video = Video::default();
+    video.snippet = Some(google_youtube3::api::VideoSnippet {
+        title: Some(opts.title.clone().unwrap_or_else(|| file_name.to_string())),
+        description: opts.description.clone(),
+        tags: opts.tags.clone(),
         ..Default::default()
-    };
+    });
+    if opts.publish_at.is_some() {
+        video.status = Some(google_youtube3::api::VideoStatus {
+            privacy_status: Some("private".to_string()),
+            publish_at: opts.publish_at.as_ref().and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok()).map(|d| d.with_timezone(&chrono::Utc)),
+            ..Default::default()
+        });
+    }
 
     let f = std::fs::File::open(&file).map_err(|e| format!("Failed to open file: {}", e))?;
     let mut reader = std::io::BufReader::new(f);
@@ -319,8 +339,8 @@ async fn build_authenticator() -> Result<Authenticator<HttpsConnector<HttpConnec
 }
 
 #[command]
-async fn upload_video(file: String) -> Result<String, String> {
-    upload_video_impl(file).await
+async fn upload_video(file: String, opts: Option<UploadOptions>) -> Result<String, String> {
+    upload_video_impl(file, opts.unwrap_or_default()).await
 }
 
 #[command]
@@ -336,17 +356,23 @@ async fn youtube_is_signed_in() -> bool {
 
 #[command]
 async fn generate_upload(window: Window, params: GenerateParams) -> Result<String, String> {
-    let output = generate_video(window.clone(), params)?;
-    let result = upload_video_impl(output.clone()).await?;
+    let output = generate_video(window.clone(), params.clone())?;
+    let result = upload_video_impl(output.clone(), UploadOptions {
+        title: params.title,
+        description: params.description,
+        tags: params.tags,
+        publish_at: params.publish_at,
+    }).await?;
     let _ = fs::remove_file(output);
     Ok(result)
 }
 
 #[command]
-async fn upload_videos(files: Vec<String>) -> Result<Vec<String>, String> {
+async fn upload_videos(files: Vec<String>, opts: Option<UploadOptions>) -> Result<Vec<String>, String> {
     let mut results = Vec::new();
+    let o = opts.unwrap_or_default();
     for file in files {
-        results.push(upload_video_impl(file).await?);
+        results.push(upload_video_impl(file, o.clone()).await?);
     }
     Ok(results)
 }
@@ -362,6 +388,10 @@ struct BatchGenerateParams {
     outro: Option<String>,
     width: Option<u32>,
     height: Option<u32>,
+    title: Option<String>,
+    description: Option<String>,
+    tags: Option<Vec<String>>,
+    publish_at: Option<String>,
 }
 
 #[command]
@@ -387,8 +417,17 @@ async fn generate_batch_upload(window: Window, params: BatchGenerateParams) -> R
             outro: params.outro.clone(),
             width: params.width,
             height: params.height,
+            title: params.title.clone(),
+            description: params.description.clone(),
+            tags: params.tags.clone(),
+            publish_at: params.publish_at.clone(),
         })?;
-        let res = upload_video_impl(video.clone()).await?;
+        let res = upload_video_impl(video.clone(), UploadOptions {
+            title: params.title.clone(),
+            description: params.description.clone(),
+            tags: params.tags.clone(),
+            publish_at: params.publish_at.clone(),
+        }).await?;
         let _ = fs::remove_file(video);
         results.push(res);
     }

--- a/ytapp/src/App.tsx
+++ b/ytapp/src/App.tsx
@@ -41,6 +41,10 @@ const App: React.FC = () => {
     const [generating, setGenerating] = useState(false);
     const [outputs, setOutputs] = useState<string[]>([]);
     const [preview, setPreview] = useState('');
+    const [title, setTitle] = useState('');
+    const [description, setDescription] = useState('');
+    const [tags, setTags] = useState('');
+    const [publishDate, setPublishDate] = useState('');
 
 
     useEffect(() => {
@@ -91,6 +95,10 @@ const App: React.FC = () => {
         outro: outro || undefined,
         width,
         height,
+        title: title || undefined,
+        description: description || undefined,
+        tags: tags ? tags.split(',').map(t => t.trim()).filter(Boolean) : undefined,
+        publishAt: publishDate ? new Date(publishDate).toISOString() : undefined,
     });
 
     const closePreview = async () => {
@@ -185,6 +193,18 @@ const App: React.FC = () => {
                     onComplete={handleTranscriptionComplete}
                 />
                 {captions && <span>{captions}</span>}
+            </div>
+            <div className="row">
+                <input type="text" placeholder={t('video_title')} value={title} onChange={e => setTitle(e.target.value)} />
+            </div>
+            <div className="row">
+                <textarea placeholder={t('description')} value={description} onChange={e => setDescription(e.target.value)} />
+            </div>
+            <div className="row">
+                <input type="text" placeholder={t('tags')} value={tags} onChange={e => setTags(e.target.value)} />
+            </div>
+            <div className="row">
+                <input type="datetime-local" value={publishDate} onChange={e => setPublishDate(e.target.value)} />
             </div>
             <details>
                 <summary>{t('advanced_settings')}</summary>

--- a/ytapp/src/cli.ts
+++ b/ytapp/src/cli.ts
@@ -19,17 +19,33 @@ interface GenerateParams {
   outro?: string;
   width?: number;
   height?: number;
+  title?: string;
+  description?: string;
+  tags?: string[];
+  publishAt?: string;
 }
 
 async function generateVideo(params: GenerateParams): Promise<any> {
   return await invoke('generate_video', params as any);
 }
 
-async function uploadVideo(params: { file: string }): Promise<any> {
+interface UploadParams {
+  file: string;
+  title?: string;
+  description?: string;
+  tags?: string[];
+  publishAt?: string;
+}
+
+interface UploadBatchParams extends Omit<UploadParams, 'file'> {
+  files: string[];
+}
+
+async function uploadVideo(params: UploadParams): Promise<any> {
   return await invoke('upload_video', params as any);
 }
 
-async function uploadVideos(params: { files: string[] }): Promise<any> {
+async function uploadVideos(params: UploadBatchParams): Promise<any> {
   return await invoke('upload_videos', params as any);
 }
 
@@ -91,6 +107,10 @@ program
   .option('--outro <file>', 'outro video or image')
   .option('--width <width>', 'output width', (v) => parseInt(v, 10))
   .option('--height <height>', 'output height', (v) => parseInt(v, 10))
+  .option('--title <title>', 'video title')
+  .option('--description <desc>', 'video description')
+  .option('--tags <tags>', 'comma separated tags')
+  .option('--publish-at <date>', 'schedule publish date (ISO)')
   .action(async (file: string, options: any) => {
     try {
       const params: GenerateParams = {
@@ -107,6 +127,10 @@ program
         outro: options.outro,
         width: options.width,
         height: options.height,
+        title: options.title,
+        description: options.description,
+        tags: options.tags ? options.tags.split(',').map((t: string) => t.trim()).filter(Boolean) : undefined,
+        publishAt: options.publishAt,
       };
       const result = await generateVideo(params);
       console.log(result);
@@ -169,6 +193,10 @@ program
   .option('--outro <file>', 'outro video or image')
   .option('--width <width>', 'output width', (v) => parseInt(v, 10))
   .option('--height <height>', 'output height', (v) => parseInt(v, 10))
+  .option('--title <title>', 'video title')
+  .option('--description <desc>', 'video description')
+  .option('--tags <tags>', 'comma separated tags')
+  .option('--publish-at <date>', 'schedule publish date (ISO)')
   .action(async (files: string[], options: any) => {
     try {
       const result = await invoke('generate_batch_upload', {
@@ -185,6 +213,10 @@ program
         outro: options.outro,
         width: options.width,
         height: options.height,
+        title: options.title,
+        description: options.description,
+        tags: options.tags ? options.tags.split(',').map((t: string) => t.trim()).filter(Boolean) : undefined,
+        publishAt: options.publishAt,
       } as any);
       console.log(result);
     } catch (err) {
@@ -240,9 +272,19 @@ program
   .command('upload')
   .description('Upload video to YouTube')
   .argument('<file>', 'video file path')
-  .action(async (file: string) => {
+  .option('--title <title>', 'video title')
+  .option('--description <desc>', 'video description')
+  .option('--tags <tags>', 'comma separated tags')
+  .option('--publish-at <date>', 'schedule publish date (ISO)')
+  .action(async (file: string, options: any) => {
     try {
-      const result = await uploadVideo({ file });
+      const result = await uploadVideo({
+        file,
+        title: options.title,
+        description: options.description,
+        tags: options.tags ? options.tags.split(',').map((t: string) => t.trim()).filter(Boolean) : undefined,
+        publishAt: options.publishAt,
+      });
       console.log(result);
     } catch (err) {
       console.error('Error uploading video:', err);
@@ -254,9 +296,19 @@ program
   .command('upload-batch')
   .description('Upload multiple videos to YouTube')
   .argument('<files...>', 'video files')
-  .action(async (files: string[]) => {
+  .option('--title <title>', 'video title')
+  .option('--description <desc>', 'video description')
+  .option('--tags <tags>', 'comma separated tags')
+  .option('--publish-at <date>', 'schedule publish date (ISO)')
+  .action(async (files: string[], options: any) => {
     try {
-      const results = await uploadVideos({ files }) as any[];
+      const results = await uploadVideos({
+        files,
+        title: options.title,
+        description: options.description,
+        tags: options.tags ? options.tags.split(',').map((t: string) => t.trim()).filter(Boolean) : undefined,
+        publishAt: options.publishAt,
+      }) as any[];
       results.forEach((res: any) => console.log(res));
     } catch (err) {
       console.error('Error uploading videos:', err);

--- a/ytapp/src/components/BatchUploader.tsx
+++ b/ytapp/src/components/BatchUploader.tsx
@@ -9,6 +9,10 @@ const BatchUploader: React.FC = () => {
     const [files, setFiles] = useState<string[]>([]);
     const [progressMap, setProgressMap] = useState<Record<string, number>>({});
     const [running, setRunning] = useState(false);
+    const [title, setTitle] = useState('');
+    const [description, setDescription] = useState('');
+    const [tags, setTags] = useState('');
+    const [publishDate, setPublishDate] = useState('');
 
     const handleSelect = (p: string | string[] | null) => {
         if (Array.isArray(p)) setFiles(p);
@@ -23,7 +27,13 @@ const BatchUploader: React.FC = () => {
         for (const file of files) {
             prog[file] = 0;
             setProgressMap({ ...prog });
-            await uploadVideo(file);
+            await uploadVideo({
+                file,
+                title: title || undefined,
+                description: description || undefined,
+                tags: tags ? tags.split(',').map(t => t.trim()).filter(Boolean) : undefined,
+                publishAt: publishDate ? new Date(publishDate).toISOString() : undefined,
+            });
             prog[file] = 100;
             setProgressMap({ ...prog });
         }
@@ -36,6 +46,18 @@ const BatchUploader: React.FC = () => {
             <div className="row">
                 <FilePicker multiple onSelect={handleSelect} label={t('select_videos')} filters={[{ name: 'Videos', extensions: ['mp4'] }]} />
                 {files.length > 0 && <p>{t('files_selected', { count: files.length })}</p>}
+            </div>
+            <div className="row">
+                <input type="text" placeholder={t('video_title')} value={title} onChange={e => setTitle(e.target.value)} />
+            </div>
+            <div className="row">
+                <textarea placeholder={t('description')} value={description} onChange={e => setDescription(e.target.value)} />
+            </div>
+            <div className="row">
+                <input type="text" placeholder={t('tags')} value={tags} onChange={e => setTags(e.target.value)} />
+            </div>
+            <div className="row">
+                <input type="datetime-local" value={publishDate} onChange={e => setPublishDate(e.target.value)} />
             </div>
             <div className="row">
                 <button onClick={startUpload} disabled={running || !files.length}>

--- a/ytapp/src/features/processing/index.ts
+++ b/ytapp/src/features/processing/index.ts
@@ -17,6 +17,10 @@ export interface GenerateParams {
     outro?: string;
     width?: number;
     height?: number;
+    title?: string;
+    description?: string;
+    tags?: string[];
+    publishAt?: string;
 }
 
 export type ProgressCallback = (progress: number) => void;

--- a/ytapp/src/features/youtube/index.ts
+++ b/ytapp/src/features/youtube/index.ts
@@ -2,12 +2,24 @@ import { invoke } from '@tauri-apps/api/core';
 import { GenerateParams } from '../processing';
 export type { GenerateParams } from '../processing';
 
-export async function uploadVideo(file: string): Promise<string> {
-    return await invoke('upload_video', { file });
+export interface UploadOptions {
+    file: string;
+    title?: string;
+    description?: string;
+    tags?: string[];
+    publishAt?: string;
 }
 
-export async function uploadVideos(files: string[]): Promise<string[]> {
-    return await invoke('upload_videos', { files });
+export interface UploadBatchOptions extends Omit<UploadOptions, 'file'> {
+    files: string[];
+}
+
+export async function uploadVideo(opts: UploadOptions): Promise<string> {
+    return await invoke('upload_video', opts);
+}
+
+export async function uploadVideos(opts: UploadBatchOptions): Promise<string[]> {
+    return await invoke('upload_videos', opts);
 }
 
 export async function generateUpload(params: GenerateParams): Promise<string> {


### PR DESCRIPTION
## Summary
- support title/description/tags/publish date in UI and CLI
- pass metadata to Rust backend and schedule YouTube upload via `publishAt`
- document new CLI usage

## Testing
- `npm install`
- `cargo check` *(fails: tauri dependencies missing)*
- `npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_6847a6f72a388331a5519f0eadcc82e2