### PR TITLE
Add caption color controls

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,8 @@
   * Font (user-selectable)
   * Size (user-selectable)
   * Position (top / center / bottom)
+  * Color
+  * Outline Color
 
 ---
 

--- a/ytapp/public/locales/en/translation.json
+++ b/ytapp/public/locales/en/translation.json
@@ -43,5 +43,7 @@
   "description": "Description",
   "tags": "Tags",
   "publish_date": "Publish Date"
+  ,"color": "Color"
+  ,"outline": "Outline Color"
 
 }

--- a/ytapp/src-tauri/src/main.rs
+++ b/ytapp/src-tauri/src/main.rs
@@ -36,6 +36,8 @@ struct CaptionOptions {
     style: Option<String>,
     size: Option<u32>,
     position: Option<String>,
+    color: Option<String>,
+    outline: Option<String>,
 }
 
 #[derive(Deserialize, Clone)]
@@ -72,6 +74,8 @@ struct AppSettings {
     caption_font_path: Option<String>,
     caption_style: Option<String>,
     caption_size: Option<u32>,
+    caption_color: Option<String>,
+    caption_outline: Option<String>,
     show_guide: Option<bool>,
 }
 
@@ -83,6 +87,8 @@ impl Default for AppSettings {
             background: None,
             caption_font: None,
             caption_size: None,
+            caption_color: None,
+            caption_outline: None,
             show_guide: Some(true),
         }
     }
@@ -131,6 +137,18 @@ fn temp_file(name: &str) -> PathBuf {
         .unwrap()
         .as_nanos();
     std::env::temp_dir().join(format!("{}_{}.mp4", name, ts))
+}
+
+fn ass_color(hex: &str) -> String {
+    let h = hex.trim_start_matches('#');
+    if h.len() == 6 {
+        let r = &h[0..2];
+        let g = &h[2..4];
+        let b = &h[4..6];
+        format!("&H00{}{}{}&", b, g, r)
+    } else {
+        hex.to_string()
+    }
 }
 
 fn run_with_progress(mut cmd: Command, duration: f64, window: &Window) -> Result<(), String> {
@@ -223,6 +241,12 @@ fn build_main_section(window: Option<&Window>, params: &GenerateParams, duration
         }
         if style.to_lowercase().contains("italic") {
             style_parts.push("Italic=1".into());
+        }
+        if let Some(col) = opts.color {
+            style_parts.push(format!("PrimaryColour={}", ass_color(&col)));
+        }
+        if let Some(out) = opts.outline {
+            style_parts.push(format!("OutlineColour={}", ass_color(&out)));
         }
         if let Some(ref path) = opts.font_path {
             let dir = Path::new(path).parent().and_then(|p| p.to_str()).unwrap_or("");

--- a/ytapp/src/App.tsx
+++ b/ytapp/src/App.tsx
@@ -12,6 +12,7 @@ import BatchPage from './components/BatchPage';
 import SettingsPage from './components/SettingsPage';
 import FontSelector from './components/FontSelector';
 import SizeSlider from './components/SizeSlider';
+import ColorPicker from './components/ColorPicker';
 import { languageOptions, Language } from './features/language';
 import TranscribeButton from './components/TranscribeButton';
 import { loadSettings, saveSettings } from './features/settings';
@@ -34,6 +35,8 @@ const App: React.FC = () => {
     const [fontStyle, setFontStyle] = useState('');
     const [size, setSize] = useState(24);
     const [position, setPosition] = useState('bottom');
+    const [color, setColor] = useState('#ffffff');
+    const [outline, setOutline] = useState('#000000');
     const [language, setLanguage] = useState<Language>('auto');
     const [width, setWidth] = useState(1280);
     const [height, setHeight] = useState(720);
@@ -61,6 +64,8 @@ const App: React.FC = () => {
             if (s.captionFontPath) setFontPath(s.captionFontPath);
             if (s.captionStyle) setFontStyle(s.captionStyle);
             if (s.captionSize) setSize(s.captionSize);
+            if (s.captionColor) setColor(s.captionColor);
+            if (s.captionOutline) setOutline(s.captionOutline);
             if (s.showGuide !== false) setShowGuide(true);
         });
     }, []);
@@ -89,6 +94,8 @@ const App: React.FC = () => {
                 style: fontStyle || undefined,
                 size,
                 position,
+                color,
+                outline,
             },
             background: background || undefined,
             intro: intro || undefined,
@@ -109,6 +116,8 @@ const App: React.FC = () => {
             style: fontStyle || undefined,
             size,
             position,
+            color,
+            outline,
         },
         background: background || undefined,
         intro: intro || undefined,
@@ -142,6 +151,8 @@ const App: React.FC = () => {
             outro: outro || undefined,
             background: background || undefined,
             captionFont: font || undefined,
+            captionColor: color,
+            captionOutline: outline,
             captionSize: size,
             showGuide: false,
         });
@@ -273,6 +284,10 @@ const App: React.FC = () => {
                         setFontStyle(f?.style || '');
                     }}
                 />
+            </div>
+            <div className="row">
+                <ColorPicker label={t('color')} value={color} onChange={setColor} />
+                <ColorPicker label={t('outline')} value={outline} onChange={setOutline} />
             </div>
             <div className="row">
                 <SizeSlider value={size} onChange={setSize} />

--- a/ytapp/src/cli.ts
+++ b/ytapp/src/cli.ts
@@ -9,6 +9,8 @@ interface CaptionOptions {
   style?: string;
   size?: number;
   position?: string;
+  color?: string;
+  outline?: string;
 }
 
 interface GenerateParams {
@@ -106,6 +108,8 @@ program
   .option('--style <style>', 'caption font style')
   .option('--size <size>', 'caption font size', (v) => parseInt(v, 10))
   .option('--position <pos>', 'caption position (top|center|bottom)')
+  .option('--color <color>', 'caption text color')
+  .option('--outline <color>', 'caption outline color')
   .option('-b, --background <file>', 'background image or video')
   .option('--intro <file>', 'intro video or image')
   .option('--outro <file>', 'outro video or image')
@@ -127,6 +131,8 @@ program
           style: options.style,
           size: options.size,
           position: options.position,
+          color: options.color,
+          outline: options.outline,
         },
         background: options.background,
         intro: options.intro,
@@ -157,6 +163,8 @@ program
   .option('--style <style>', 'caption font style')
   .option('--size <size>', 'caption font size', (v) => parseInt(v, 10))
   .option('--position <pos>', 'caption position (top|center|bottom)')
+  .option('--color <color>', 'caption text color')
+  .option('--outline <color>', 'caption outline color')
   .option('-b, --background <file>', 'background image or video')
   .option('--intro <file>', 'intro video or image')
   .option('--outro <file>', 'outro video or image')
@@ -174,6 +182,8 @@ program
           style: options.style,
           size: options.size,
           position: options.position,
+          color: options.color,
+          outline: options.outline,
         },
         background: options.background,
         intro: options.intro,
@@ -200,6 +210,8 @@ program
   .option('--style <style>', 'caption font style')
   .option('--size <size>', 'caption font size', (v) => parseInt(v, 10))
   .option('--position <pos>', 'caption position (top|center|bottom)')
+  .option('--color <color>', 'caption text color')
+  .option('--outline <color>', 'caption outline color')
   .option('-b, --background <file>', 'background image or video')
   .option('--intro <file>', 'intro video or image')
   .option('--outro <file>', 'outro video or image')
@@ -221,6 +233,8 @@ program
           style: options.style,
           size: options.size,
           position: options.position,
+          color: options.color,
+          outline: options.outline,
         },
         background: options.background,
         intro: options.intro,
@@ -248,6 +262,8 @@ program
   .option('--font <font>', 'caption font')
   .option('--size <size>', 'caption font size', (v) => parseInt(v, 10))
   .option('--position <pos>', 'caption position (top|center|bottom)')
+  .option('--color <color>', 'caption text color')
+  .option('--outline <color>', 'caption outline color')
   .option('-b, --background <file>', 'background image or video')
   .option('--intro <file>', 'intro video or image')
   .option('--outro <file>', 'outro video or image')
@@ -265,12 +281,14 @@ program
           output,
           captions: options.captions,
           captionOptions: {
-            font: options.font,
-            fontPath: options.fontPath,
-            style: options.style,
-            size: options.size,
-            position: options.position,
-          },
+          font: options.font,
+          fontPath: options.fontPath,
+          style: options.style,
+          size: options.size,
+          position: options.position,
+          color: options.color,
+          outline: options.outline,
+        },
           background: options.background,
           intro: options.intro,
           outro: options.outro,

--- a/ytapp/src/components/BatchOptionsForm.tsx
+++ b/ytapp/src/components/BatchOptionsForm.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import FilePicker from './FilePicker';
 import FontSelector from './FontSelector';
 import SizeSlider from './SizeSlider';
+import ColorPicker from './ColorPicker';
 import { BatchOptions } from '../features/batch';
 
 interface BatchOptionsFormProps {
@@ -60,6 +61,10 @@ const BatchOptionsForm: React.FC<BatchOptionsFormProps> = ({ value, onChange }) 
                     } : null}
                     onChange={(f) => update({ captionOptions: { font: f?.name, fontPath: f?.path, style: f?.style } })}
                 />
+            </div>
+            <div className="row">
+                <ColorPicker label={t('color')} value={value.captionOptions?.color || '#ffffff'} onChange={c => update({ captionOptions: { color: c } })} />
+                <ColorPicker label={t('outline')} value={value.captionOptions?.outline || '#000000'} onChange={o => update({ captionOptions: { outline: o } })} />
             </div>
             <div className="row">
                 <SizeSlider value={value.captionOptions?.size || 24} onChange={(s) => update({ captionOptions: { size: s } })} />

--- a/ytapp/src/components/ColorPicker.tsx
+++ b/ytapp/src/components/ColorPicker.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface ColorPickerProps {
+    value: string;
+    onChange: (c: string) => void;
+    label?: string;
+}
+
+const ColorPicker: React.FC<ColorPickerProps> = ({ value, onChange, label }) => {
+    const { t } = useTranslation();
+    return (
+        <label>
+            {label || t('color')}
+            <input
+                type="color"
+                value={value}
+                onChange={e => onChange(e.target.value)}
+                style={{ marginLeft: '0.5em' }}
+            />
+        </label>
+    );
+};
+
+export default ColorPicker;

--- a/ytapp/src/components/SettingsPage.tsx
+++ b/ytapp/src/components/SettingsPage.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import FilePicker from './FilePicker';
 import FontSelector from './FontSelector';
 import SizeSlider from './SizeSlider';
+import ColorPicker from './ColorPicker';
 import { loadSettings, saveSettings } from '../features/settings';
 
 const SettingsPage: React.FC = () => {
@@ -14,6 +15,8 @@ const SettingsPage: React.FC = () => {
     const [fontPath, setFontPath] = useState('');
     const [fontStyle, setFontStyle] = useState('');
     const [size, setSize] = useState(24);
+    const [color, setColor] = useState('#ffffff');
+    const [outline, setOutline] = useState('#000000');
     const [guide, setGuide] = useState(true);
 
     useEffect(() => {
@@ -25,6 +28,8 @@ const SettingsPage: React.FC = () => {
             setFontPath(s.captionFontPath || '');
             setFontStyle(s.captionStyle || '');
             setSize(s.captionSize || 24);
+            setColor(s.captionColor || '#ffffff');
+            setOutline(s.captionOutline || '#000000');
             setGuide(s.showGuide !== false);
         });
     }, []);
@@ -38,6 +43,8 @@ const SettingsPage: React.FC = () => {
             captionFontPath: fontPath || undefined,
             captionStyle: fontStyle || undefined,
             captionSize: size,
+            captionColor: color,
+            captionOutline: outline,
             showGuide: guide,
         });
     };
@@ -87,6 +94,10 @@ const SettingsPage: React.FC = () => {
                         setFontStyle(f?.style || '');
                     }}
                 />
+            </div>
+            <div>
+                <ColorPicker label={t('color')} value={color} onChange={setColor} />
+                <ColorPicker label={t('outline')} value={outline} onChange={setOutline} />
             </div>
             <div>
                 <SizeSlider value={size} onChange={setSize} />

--- a/ytapp/src/features/processing/index.ts
+++ b/ytapp/src/features/processing/index.ts
@@ -7,6 +7,8 @@ export interface CaptionOptions {
     style?: string;
     size?: number;
     position?: string;
+    color?: string;
+    outline?: string;
 }
 
 export interface GenerateParams {

--- a/ytapp/src/features/settings/index.ts
+++ b/ytapp/src/features/settings/index.ts
@@ -8,6 +8,8 @@ export interface Settings {
     captionFontPath?: string;
     captionStyle?: string;
     captionSize?: number;
+    captionColor?: string;
+    captionOutline?: string;
     showGuide?: boolean;
 }
 


### PR DESCRIPTION
## Summary
- support caption colors in CaptionOptions (TypeScript/Rust)
- generate ASS color styles in FFmpeg filter
- add color pickers to UI and settings
- expose `--color` and `--outline` options in CLI
- document caption color options in README

## Testing
- `npm install`
- `cargo check` *(fails: `pkg-config` could not find `glib-2.0`)*
- `npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_68483361cce88331a6366f3c9b9d8147