### PR TITLE
Centralize language definitions

### DIFF
--- a/ytapp/src/App.tsx
+++ b/ytapp/src/App.tsx
@@ -12,7 +12,7 @@ import BatchPage from './components/BatchPage';
 import SettingsPage from './components/SettingsPage';
 import FontSelector from './components/FontSelector';
 import SizeSlider from './components/SizeSlider';
-import { languageOptions, Language } from './features/language';
+import { languages, Language } from './features/languages';
 import TranscribeButton from './components/TranscribeButton';
 import { loadSettings, saveSettings } from './features/settings';
 import Modal from './components/Modal';
@@ -76,8 +76,8 @@ const App: React.FC = () => {
     }, [theme]);
 
     useEffect(() => {
-        const rtl = ['ar', 'he', 'fa', 'ur'].includes(i18n.language);
-        document.documentElement.dir = rtl ? 'rtl' : 'ltr';
+        const lang = languages.find(l => l.value === i18n.language);
+        document.documentElement.dir = lang && lang.rtl ? 'rtl' : 'ltr';
     }, [i18n.language]);
 
     const toggleTheme = () =>
@@ -225,42 +225,9 @@ const App: React.FC = () => {
             <h1>{t('title')}</h1>
             <div className="row">
                 <select value={i18n.language} onChange={e => i18n.changeLanguage(e.target.value)}>
-                    <option value="en">English</option>
-                    <option value="ne">नेपाली</option>
-                    <option value="hi">हिन्दी</option>
-                    <option value="es">Español</option>
-                    <option value="fr">Français</option>
-                    <option value="zh">中文</option>
-                    <option value="ar">العربية</option>
-                    <option value="pt">Português</option>
-                    <option value="ru">Русский</option>
-                    <option value="ja">日本語</option>
-                    <option value="de">Deutsch</option>
-                    <option value="it">Italiano</option>
-                    <option value="ko">한국어</option>
-                    <option value="vi">Tiếng Việt</option>
-                    <option value="tr">Türkçe</option>
-                    <option value="id">Bahasa Indonesia</option>
-                    <option value="nl">Nederlands</option>
-                    <option value="th">ไทย</option>
-                    <option value="pl">Polski</option>
-                    <option value="sv">Svenska</option>
-                    <option value="fi">Suomi</option>
-                    <option value="he">עברית</option>
-                    <option value="uk">Українська</option>
-                    <option value="el">Ελληνικά</option>
-                    <option value="ms">Bahasa Melayu</option>
-                    <option value="cs">Čeština</option>
-                    <option value="ro">Română</option>
-                    <option value="da">Dansk</option>
-                    <option value="hu">Magyar</option>
-                    <option value="no">Norsk</option>
-                    <option value="ur">اردو</option>
-                    <option value="hr">Hrvatski</option>
-                    <option value="bg">Български</option>
-                    <option value="lt">Lietuvių</option>
-                    <option value="lv">Latviešu</option>
-                    <option value="sk">Slovenčina</option>
+                    {languages.map(lang => (
+                        <option key={lang.value} value={lang.value}>{lang.label}</option>
+                    ))}
                 </select>
                 <button onClick={toggleTheme}>{t('toggle_theme')}</button>
             </div>
@@ -379,13 +346,13 @@ const App: React.FC = () => {
             </details>
             <div className="row">
                 <select value={language} onChange={(e) => setLanguage(e.target.value as Language)}>
-                    {languageOptions.map(opt => (
+                    {languages.map(opt => (
                         <option key={opt.value} value={opt.value}>{opt.label}</option>
                     ))}
                 </select>
             </div>
             <div className="row">
-                {languageOptions.filter(opt => opt.value !== 'auto').map(opt => (
+                {languages.filter(opt => opt.value !== 'auto').map(opt => (
                     <label key={opt.value} style={{ marginRight: '0.5em' }}>
                         <input
                             type="checkbox"

--- a/ytapp/src/features/language.ts
+++ b/ytapp/src/features/language.ts
@@ -1,45 +1,7 @@
-export const languageOptions = [
-  { value: 'auto', label: 'Auto' },
-  { value: 'ne', label: 'Nepali' },
-  { value: 'hi', label: 'Hindi' },
-  { value: 'en', label: 'English' },
-  { value: 'es', label: 'Spanish' },
-  { value: 'fr', label: 'French' },
-  { value: 'zh', label: 'Chinese' },
-  { value: 'ar', label: 'Arabic' },
-  { value: 'pt', label: 'Portuguese' },
-  { value: 'ru', label: 'Russian' },
-  { value: 'ja', label: 'Japanese' },
-  { value: 'de', label: 'German' },
-  { value: 'it', label: 'Italian' },
-  { value: 'ko', label: 'Korean' },
-  { value: 'vi', label: 'Vietnamese' },
-  { value: 'tr', label: 'Turkish' },
-  { value: 'id', label: 'Indonesian' },
-  { value: 'nl', label: 'Dutch' },
-  { value: 'th', label: 'Thai' },
-  { value: 'pl', label: 'Polish' },
-  { value: 'sv', label: 'Swedish' },
-  { value: 'fi', label: 'Finnish' },
-  { value: 'he', label: 'Hebrew' },
-  { value: 'uk', label: 'Ukrainian' },
-  { value: 'el', label: 'Greek' },
-  { value: 'ms', label: 'Malay' },
-  { value: 'cs', label: 'Czech' },
-  { value: 'ro', label: 'Romanian' },
-  { value: 'da', label: 'Danish' },
-  { value: 'hu', label: 'Hungarian' },
-  { value: 'no', label: 'Norwegian' },
-  { value: 'ur', label: 'Urdu' },
-  { value: 'hr', label: 'Croatian' },
-  { value: 'bg', label: 'Bulgarian' },
-  { value: 'lt', label: 'Lithuanian' },
-  { value: 'lv', label: 'Latvian' },
-  { value: 'sk', label: 'Slovak' },
-] as const;
+import { languages, Language, isLanguage } from './languages';
 
-export type Language = typeof languageOptions[number]['value'];
+// Backwards compatibility: expose the languages array under the old name.
+export const languageOptions = languages;
 
-export function isLanguage(value: string): value is Language {
-  return languageOptions.some(opt => opt.value === value);
-}
+export type { Language };
+export { isLanguage };

--- a/ytapp/src/features/languages/index.ts
+++ b/ytapp/src/features/languages/index.ts
@@ -1,0 +1,52 @@
+// List of languages supported across the application. Each entry contains the
+// language code, human readable label and whether the language is written from
+// right-to-left.
+export const languages = [
+  { value: 'auto', label: 'Auto', rtl: false },
+  { value: 'ne', label: 'Nepali', rtl: false },
+  { value: 'hi', label: 'Hindi', rtl: false },
+  { value: 'en', label: 'English', rtl: false },
+  { value: 'es', label: 'Spanish', rtl: false },
+  { value: 'fr', label: 'French', rtl: false },
+  { value: 'zh', label: 'Chinese', rtl: false },
+  { value: 'ar', label: 'Arabic', rtl: true },
+  { value: 'pt', label: 'Portuguese', rtl: false },
+  { value: 'ru', label: 'Russian', rtl: false },
+  { value: 'ja', label: 'Japanese', rtl: false },
+  { value: 'de', label: 'German', rtl: false },
+  { value: 'it', label: 'Italian', rtl: false },
+  { value: 'ko', label: 'Korean', rtl: false },
+  { value: 'vi', label: 'Vietnamese', rtl: false },
+  { value: 'tr', label: 'Turkish', rtl: false },
+  { value: 'id', label: 'Indonesian', rtl: false },
+  { value: 'nl', label: 'Dutch', rtl: false },
+  { value: 'th', label: 'Thai', rtl: false },
+  { value: 'pl', label: 'Polish', rtl: false },
+  { value: 'sv', label: 'Swedish', rtl: false },
+  { value: 'fi', label: 'Finnish', rtl: false },
+  { value: 'he', label: 'Hebrew', rtl: true },
+  { value: 'uk', label: 'Ukrainian', rtl: false },
+  { value: 'el', label: 'Greek', rtl: false },
+  { value: 'ms', label: 'Malay', rtl: false },
+  { value: 'cs', label: 'Czech', rtl: false },
+  { value: 'ro', label: 'Romanian', rtl: false },
+  { value: 'da', label: 'Danish', rtl: false },
+  { value: 'hu', label: 'Hungarian', rtl: false },
+  { value: 'no', label: 'Norwegian', rtl: false },
+  { value: 'ur', label: 'Urdu', rtl: true },
+  { value: 'hr', label: 'Croatian', rtl: false },
+  { value: 'bg', label: 'Bulgarian', rtl: false },
+  { value: 'lt', label: 'Lithuanian', rtl: false },
+  { value: 'lv', label: 'Latvian', rtl: false },
+  { value: 'sk', label: 'Slovak', rtl: false },
+] as const;
+
+/** Language code union derived from the languages list. */
+export type Language = typeof languages[number]['value'];
+
+/**
+ * Checks whether the provided value is one of the supported language codes.
+ */
+export function isLanguage(value: string): value is Language {
+  return languages.some(l => l.value === value);
+}

--- a/ytapp/src/i18n.ts
+++ b/ytapp/src/i18n.ts
@@ -16,26 +16,35 @@ import ko from '../public/locales/ko/translation.json';
 import vi from '../public/locales/vi/translation.json';
 import tr from '../public/locales/tr/translation.json';
 import id from '../public/locales/id/translation.json';
+import { languages } from './features/languages';
+
+const translations: Record<string, any> = {
+  en,
+  ne,
+  hi,
+  es,
+  fr,
+  zh,
+  ar,
+  pt,
+  ru,
+  ja,
+  de,
+  it,
+  ko,
+  vi,
+  tr,
+  id,
+};
+
+const resources = languages.reduce<Record<string, { translation: any }>>((acc, l) => {
+  const t = translations[l.value];
+  if (t) acc[l.value] = { translation: t };
+  return acc;
+}, {});
 
 i18n.use(initReactI18next).init({
-  resources: {
-    en: { translation: en },
-    ne: { translation: ne },
-    hi: { translation: hi },
-    es: { translation: es },
-    fr: { translation: fr },
-    zh: { translation: zh },
-    ar: { translation: ar },
-    pt: { translation: pt },
-    ru: { translation: ru },
-    ja: { translation: ja },
-    de: { translation: de },
-    it: { translation: it },
-    ko: { translation: ko },
-    vi: { translation: vi },
-    tr: { translation: tr },
-    id: { translation: id },
-  },
+  resources,
   lng: 'en',
   fallbackLng: 'en',
   interpolation: { escapeValue: false },


### PR DESCRIPTION
## Summary
- add languages module with language metadata
- re-export unified list from old `language.ts`
- generate i18n resources from shared data
- refactor `App.tsx` to use new languages list

## Testing
- `npm install` *(fails: none)*
- `cargo check` *(fails: missing system libraries and build errors)*
- `npx ts-node src/cli.ts --help` *(failed: module 'yn' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848436737ac8331918427fcdc724f20