### PR TITLE
Add dynamic language support

### DIFF
--- a/design.md
+++ b/design.md
@@ -36,6 +36,8 @@ This project follows a minimalist approach inspired by the principle **"Less but
 - Action buttons may include small SVG icons for clarity.
 - Components should remain visually quiet, leaving generous whitespace around elements.
 - Typography scales in small increments (1.25x) for harmony.
+- When localizing the interface, allow generous horizontal space so text
+  expansion in other languages does not break layouts.
 
 Inspired by the work of Dieter Rams and Jony Ive, these rules emphasize clarity, restrained color use and quiet motion.
 Always strive for "as little design as possible".

--- a/readme.md
+++ b/readme.md
@@ -30,24 +30,9 @@
 
 * OpenAI Whisper ([https://github.com/openai/whisper](https://github.com/openai/whisper)), local model
 * Transcribe input audio
-* Supported languages (with automatic detection when "Auto" is selected):
-
-  * Nepali
-  * Hindi
-  * English
-  * Spanish
-  * French
-  * Chinese
-  * Arabic
-  * Portuguese
-  * Russian
-  * Japanese
-  * German
-  * Italian
-  * Korean
-  * Vietnamese
-  * Turkish
-  * Indonesian
+* Supported languages (with automatic detection when "Auto" is selected)
+  are defined in `shared/languages.json`. Whisper currently supports 99
+  languages so captions and transcripts can be generated worldwide.
 * Output `.srt` file
 * Burn `.srt` captions into video using FFmpeg:
 
@@ -109,7 +94,8 @@
 * Settings page with persistent defaults
 * Interface translations (English, Nepali, Hindi, Spanish, French, Chinese,
   Arabic, Portuguese, Russian, Japanese, German, Italian, Korean,
-  Vietnamese, Turkish, Indonesian)
+  Vietnamese, Turkish, Indonesian) with additional languages easily
+  extendable via `public/locales`.
 * Video preview modal after generation
 
 ---

--- a/ytapp/shared/languages.json
+++ b/ytapp/shared/languages.json
@@ -1,0 +1,398 @@
+[
+  {
+    "code": "en",
+    "label": "English"
+  },
+  {
+    "code": "zh",
+    "label": "Chinese"
+  },
+  {
+    "code": "de",
+    "label": "German"
+  },
+  {
+    "code": "es",
+    "label": "Spanish"
+  },
+  {
+    "code": "ru",
+    "label": "Russian"
+  },
+  {
+    "code": "ko",
+    "label": "Korean"
+  },
+  {
+    "code": "fr",
+    "label": "French"
+  },
+  {
+    "code": "ja",
+    "label": "Japanese"
+  },
+  {
+    "code": "pt",
+    "label": "Portuguese"
+  },
+  {
+    "code": "tr",
+    "label": "Turkish"
+  },
+  {
+    "code": "pl",
+    "label": "Polish"
+  },
+  {
+    "code": "ca",
+    "label": "Catalan"
+  },
+  {
+    "code": "nl",
+    "label": "Dutch"
+  },
+  {
+    "code": "ar",
+    "label": "Arabic"
+  },
+  {
+    "code": "sv",
+    "label": "Swedish"
+  },
+  {
+    "code": "it",
+    "label": "Italian"
+  },
+  {
+    "code": "id",
+    "label": "Indonesian"
+  },
+  {
+    "code": "hi",
+    "label": "Hindi"
+  },
+  {
+    "code": "fi",
+    "label": "Finnish"
+  },
+  {
+    "code": "vi",
+    "label": "Vietnamese"
+  },
+  {
+    "code": "he",
+    "label": "Hebrew"
+  },
+  {
+    "code": "uk",
+    "label": "Ukrainian"
+  },
+  {
+    "code": "el",
+    "label": "Greek"
+  },
+  {
+    "code": "ms",
+    "label": "Malay"
+  },
+  {
+    "code": "cs",
+    "label": "Czech"
+  },
+  {
+    "code": "ro",
+    "label": "Romanian"
+  },
+  {
+    "code": "da",
+    "label": "Danish"
+  },
+  {
+    "code": "hu",
+    "label": "Hungarian"
+  },
+  {
+    "code": "ta",
+    "label": "Tamil"
+  },
+  {
+    "code": "no",
+    "label": "Norwegian"
+  },
+  {
+    "code": "th",
+    "label": "Thai"
+  },
+  {
+    "code": "ur",
+    "label": "Urdu"
+  },
+  {
+    "code": "hr",
+    "label": "Croatian"
+  },
+  {
+    "code": "bg",
+    "label": "Bulgarian"
+  },
+  {
+    "code": "lt",
+    "label": "Lithuanian"
+  },
+  {
+    "code": "la",
+    "label": "Latin"
+  },
+  {
+    "code": "mi",
+    "label": "Maori"
+  },
+  {
+    "code": "ml",
+    "label": "Malayalam"
+  },
+  {
+    "code": "cy",
+    "label": "Welsh"
+  },
+  {
+    "code": "sk",
+    "label": "Slovak"
+  },
+  {
+    "code": "te",
+    "label": "Telugu"
+  },
+  {
+    "code": "fa",
+    "label": "Persian"
+  },
+  {
+    "code": "lv",
+    "label": "Latvian"
+  },
+  {
+    "code": "bn",
+    "label": "Bengali"
+  },
+  {
+    "code": "sr",
+    "label": "Serbian"
+  },
+  {
+    "code": "az",
+    "label": "Azerbaijani"
+  },
+  {
+    "code": "sl",
+    "label": "Slovenian"
+  },
+  {
+    "code": "kn",
+    "label": "Kannada"
+  },
+  {
+    "code": "et",
+    "label": "Estonian"
+  },
+  {
+    "code": "mk",
+    "label": "Macedonian"
+  },
+  {
+    "code": "br",
+    "label": "Breton"
+  },
+  {
+    "code": "eu",
+    "label": "Basque"
+  },
+  {
+    "code": "is",
+    "label": "Icelandic"
+  },
+  {
+    "code": "hy",
+    "label": "Armenian"
+  },
+  {
+    "code": "ne",
+    "label": "Nepali"
+  },
+  {
+    "code": "mn",
+    "label": "Mongolian"
+  },
+  {
+    "code": "bs",
+    "label": "Bosnian"
+  },
+  {
+    "code": "kk",
+    "label": "Kazakh"
+  },
+  {
+    "code": "sq",
+    "label": "Albanian"
+  },
+  {
+    "code": "sw",
+    "label": "Swahili"
+  },
+  {
+    "code": "gl",
+    "label": "Galician"
+  },
+  {
+    "code": "mr",
+    "label": "Marathi"
+  },
+  {
+    "code": "pa",
+    "label": "Punjabi"
+  },
+  {
+    "code": "si",
+    "label": "Sinhala"
+  },
+  {
+    "code": "km",
+    "label": "Khmer"
+  },
+  {
+    "code": "sn",
+    "label": "Shona"
+  },
+  {
+    "code": "yo",
+    "label": "Yoruba"
+  },
+  {
+    "code": "so",
+    "label": "Somali"
+  },
+  {
+    "code": "af",
+    "label": "Afrikaans"
+  },
+  {
+    "code": "oc",
+    "label": "Occitan"
+  },
+  {
+    "code": "ka",
+    "label": "Georgian"
+  },
+  {
+    "code": "be",
+    "label": "Belarusian"
+  },
+  {
+    "code": "tg",
+    "label": "Tajik"
+  },
+  {
+    "code": "sd",
+    "label": "Sindhi"
+  },
+  {
+    "code": "gu",
+    "label": "Gujarati"
+  },
+  {
+    "code": "am",
+    "label": "Amharic"
+  },
+  {
+    "code": "yi",
+    "label": "Yiddish"
+  },
+  {
+    "code": "lo",
+    "label": "Lao"
+  },
+  {
+    "code": "uz",
+    "label": "Uzbek"
+  },
+  {
+    "code": "fo",
+    "label": "Faroese"
+  },
+  {
+    "code": "ht",
+    "label": "Haitian Creole"
+  },
+  {
+    "code": "ps",
+    "label": "Pashto"
+  },
+  {
+    "code": "tk",
+    "label": "Turkmen"
+  },
+  {
+    "code": "nn",
+    "label": "Nynorsk"
+  },
+  {
+    "code": "mt",
+    "label": "Maltese"
+  },
+  {
+    "code": "sa",
+    "label": "Sanskrit"
+  },
+  {
+    "code": "lb",
+    "label": "Luxembourgish"
+  },
+  {
+    "code": "my",
+    "label": "Myanmar"
+  },
+  {
+    "code": "bo",
+    "label": "Tibetan"
+  },
+  {
+    "code": "tl",
+    "label": "Tagalog"
+  },
+  {
+    "code": "mg",
+    "label": "Malagasy"
+  },
+  {
+    "code": "as",
+    "label": "Assamese"
+  },
+  {
+    "code": "tt",
+    "label": "Tatar"
+  },
+  {
+    "code": "haw",
+    "label": "Hawaiian"
+  },
+  {
+    "code": "ln",
+    "label": "Lingala"
+  },
+  {
+    "code": "ha",
+    "label": "Hausa"
+  },
+  {
+    "code": "ba",
+    "label": "Bashkir"
+  },
+  {
+    "code": "jw",
+    "label": "Javanese"
+  },
+  {
+    "code": "su",
+    "label": "Sundanese"
+  }
+]

--- a/ytapp/src-tauri/src/language.rs
+++ b/ytapp/src-tauri/src/language.rs
@@ -1,27 +1,16 @@
 use whisper_cli::Language;
+use std::str::FromStr;
 
 /// Parse an optional language code into the `whisper_cli` `Language` enum.
 ///
 /// Returns `None` when the language should be auto-detected.
 pub fn parse_language(code: Option<String>) -> Option<Language> {
-    match code.as_deref() {
-        Some("ne") | Some("nepali") => Some(Language::Nepali),
-        Some("hi") | Some("hindi") => Some(Language::Hindi),
-        Some("en") | Some("english") => Some(Language::English),
-        Some("es") | Some("spanish") => Some(Language::Spanish),
-        Some("fr") | Some("french") => Some(Language::French),
-        Some("zh") | Some("chinese") => Some(Language::Chinese),
-        Some("ar") | Some("arabic") => Some(Language::Arabic),
-        Some("pt") | Some("portuguese") => Some(Language::Portuguese),
-        Some("ru") | Some("russian") => Some(Language::Russian),
-        Some("ja") | Some("japanese") => Some(Language::Japanese),
-        Some("de") | Some("german") => Some(Language::German),
-        Some("it") | Some("italian") => Some(Language::Italian),
-        Some("ko") | Some("korean") => Some(Language::Korean),
-        Some("vi") | Some("vietnamese") => Some(Language::Vietnamese),
-        Some("tr") | Some("turkish") => Some(Language::Turkish),
-        Some("id") | Some("indonesian") => Some(Language::Indonesian),
-        Some("auto") | None => None,
-        _ => None,
+    let c = match code {
+        Some(c) => c,
+        None => return None,
+    };
+    if c == "auto" {
+        return None;
     }
+    Language::from_str(&c, false).ok()
 }

--- a/ytapp/src/cli.ts
+++ b/ytapp/src/cli.ts
@@ -2,6 +2,9 @@ import { program } from 'commander';
 import { invoke } from '@tauri-apps/api/core';
 import path from 'path';
 import { spawn } from 'child_process';
+import languages from '../shared/languages.json';
+
+const codes = languages.map(l => l.code).join('|');
 
 interface CaptionOptions {
   font?: string;
@@ -349,7 +352,7 @@ program
   .command('transcribe')
   .description('Transcribe audio to SRT')
   .argument('<file>', 'audio file path')
-  .option('-l, --language <lang>', 'language code (auto|ne|hi|en)', 'auto')
+  .option('-l, --language <lang>', `language code (auto|${codes})`, 'auto')
   // Specify one or more target language codes using multiple -t options
   .option('-t, --translate <lang...>', 'translate subtitles to languages')
   .action(async (file: string, options: any) => {

--- a/ytapp/src/features/language.ts
+++ b/ytapp/src/features/language.ts
@@ -1,22 +1,9 @@
-export const languageOptions = [
+import allLanguages from '../../shared/languages.json';
+
+export const languageOptions = ([
   { value: 'auto', label: 'Auto' },
-  { value: 'ne', label: 'Nepali' },
-  { value: 'hi', label: 'Hindi' },
-  { value: 'en', label: 'English' },
-  { value: 'es', label: 'Spanish' },
-  { value: 'fr', label: 'French' },
-  { value: 'zh', label: 'Chinese' },
-  { value: 'ar', label: 'Arabic' },
-  { value: 'pt', label: 'Portuguese' },
-  { value: 'ru', label: 'Russian' },
-  { value: 'ja', label: 'Japanese' },
-  { value: 'de', label: 'German' },
-  { value: 'it', label: 'Italian' },
-  { value: 'ko', label: 'Korean' },
-  { value: 'vi', label: 'Vietnamese' },
-  { value: 'tr', label: 'Turkish' },
-  { value: 'id', label: 'Indonesian' },
-] as const;
+  ...allLanguages.map(l => ({ value: l.code, label: l.label })),
+] as const);
 
 export type Language = typeof languageOptions[number]['value'];
 


### PR DESCRIPTION
## Summary
- generate `languages.json` from Whisper CLI data
- load languages from the shared JSON in the UI and CLI
- simplify language parsing in the Rust backend
- document the new language list and how to extend it
- note localization layout advice in the design guide

## Testing
- `npm install`
- `cargo check` *(fails: could not compile `ytapp` due to 9 previous errors)*
- `npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_68483edefed083319da6ebbd62184495