### PR TITLE
Fix missing token key handling

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -131,6 +131,7 @@
   * Implemented in Rust backend using google-youtube3 crate
   * Requires `client_secret.json` path via `YOUTUBE_CLIENT_SECRET` env variable
   * Tokens stored in `youtube_tokens.json`
+  * Encryption key via `YOUTUBE_TOKEN_KEY` env variable (32 bytes)
 * Publish dates entered in the UI use your local time zone and are converted to UTC on upload
 * Batch upload support
 


### PR DESCRIPTION
## Summary
- enforce `YOUTUBE_TOKEN_KEY` presence and length in authenticator
- document `YOUTUBE_TOKEN_KEY` env var

## Testing
- `npm install` in `ytapp`
- `cargo check` *(fails: `OUT_DIR env var is not set ...`)*
- `npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_684882a7def08331941dbf70ca34b9cb