### PR TITLE
Add caption color flags to CLI

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -289,5 +289,8 @@ Upload an existing video with metadata:
 npx ts-node src/cli.ts upload video.mp4 --title "My Video"
 ```
 
+The `generate` and `batch` commands also accept `--color` and `--bg-color` to
+set the caption text and background colors.
+
 
 

--- a/ytapp/src/cli.ts
+++ b/ytapp/src/cli.ts
@@ -10,6 +10,8 @@ interface CaptionOptions {
   style?: string;
   size?: number;
   position?: string;
+  color?: string;
+  background?: string;
 }
 
 interface GenerateParams {
@@ -110,6 +112,8 @@ program
   .option('--style <style>', 'caption font style')
   .option('--size <size>', 'caption font size', (v) => parseInt(v, 10))
   .option('--position <pos>', 'caption position (top|center|bottom)')
+  .option('--color <hex>', 'caption text color')
+  .option('--bg-color <hex>', 'caption background color')
   .option('-b, --background <file>', 'background image or video')
   .option('--intro <file>', 'intro video or image')
   .option('--outro <file>', 'outro video or image')
@@ -131,6 +135,8 @@ program
           style: options.style,
           size: options.size,
           position: options.position,
+          color: options.color,
+          background: options.bgColor,
         },
         background: options.background,
         intro: options.intro,
@@ -250,6 +256,8 @@ program
   .option('-d, --output-dir <dir>', 'output directory', '.')
   .option('--captions <srt>', 'captions file path')
   .option('--font <font>', 'caption font')
+  .option('--color <hex>', 'caption text color')
+  .option('--bg-color <hex>', 'caption background color')
   .option('--size <size>', 'caption font size', (v) => parseInt(v, 10))
   .option('--position <pos>', 'caption position (top|center|bottom)')
   .option('-b, --background <file>', 'background image or video')
@@ -274,6 +282,8 @@ program
             style: options.style,
             size: options.size,
             position: options.position,
+            color: options.color,
+            background: options.bgColor,
           },
           background: options.background,
           intro: options.intro,


### PR DESCRIPTION
## Summary
- extend `CaptionOptions` with `color` and `background`
- allow `--color` and `--bg-color` for `generate` and `batch` commands
- document new CLI flags

## Testing
- `npm install`
- `./scripts/install_tauri_deps.sh`
- `cargo check` *(fails: could not compile `ytapp` due to errors)*
- `npx ts-node src/cli.ts --help`
- `npx ts-node src/cli.ts generate --help`
- `npx ts-node src/cli.ts batch --help`

------
https://chatgpt.com/codex/tasks/task_e_684882a2bb3c83318bb7f0ed0c9b73fb