### PR TITLE
Add CLI options and improve dependency checks

### DIFF
--- a/ytapp/src-tauri/src/language.rs
+++ b/ytapp/src-tauri/src/language.rs
@@ -73,3 +73,21 @@ pub fn parse_language(code: Option<String>) -> Option<Language> {
         _ => None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_known_codes() {
+        assert_eq!(parse_language(Some("en".into())), Some(Language::English));
+        assert_eq!(parse_language(Some("ne".into())), Some(Language::Nepali));
+    }
+
+    #[test]
+    fn handles_auto_and_unknown() {
+        assert_eq!(parse_language(Some("auto".into())), None);
+        assert_eq!(parse_language(Some("xx".into())), None);
+        assert_eq!(parse_language(None), None);
+    }
+}

--- a/ytapp/src-tauri/src/main.rs
+++ b/ytapp/src-tauri/src/main.rs
@@ -408,7 +408,8 @@ async fn build_authenticator() -> Result<Authenticator<HttpsConnector<HttpConnec
         .map_err(|e| format!("Failed to read client secret: {}", e))?;
 
     let token_path = std::env::var("YOUTUBE_TOKEN_FILE").unwrap_or_else(|_| "youtube_tokens.enc".into());
-    let key_env = std::env::var("YOUTUBE_TOKEN_KEY").unwrap_or_else(|_| "0123456789abcdef0123456789abcdef".into());
+    let key_env = std::env::var("YOUTUBE_TOKEN_KEY")
+        .map_err(|_| "YOUTUBE_TOKEN_KEY not set".to_string())?;
     let mut key = [0u8; 32];
     for (i, b) in key_env.as_bytes().iter().take(32).enumerate() {
         key[i] = *b;
@@ -599,6 +600,13 @@ fn verify_dependencies(app: tauri::AppHandle) -> Result<(), String> {
             .kind(MessageDialogKind::Error)
             .show();
         return Err("ffmpeg not found".into());
+    }
+
+    if Command::new("argos-translate").arg("--version").output().is_err() {
+        MessageDialogBuilder::new("Missing Argos Translate", "argos-translate is required for subtitle translation. Please install it and ensure it is in your PATH.")
+            .kind(MessageDialogKind::Error)
+            .show();
+        return Err("argos-translate not found".into());
     }
 
     let model = Model::new(Size::Base);


### PR DESCRIPTION
## Summary
- expose caption color and background options in CLI
- show progress in CLI when generating videos
- check `argos-translate` during dependency verification
- require explicit `YOUTUBE_TOKEN_KEY`
- add basic language parser tests

## Testing
- `npm install`
- `cargo check` *(fails: `gdk-3.0.pc` not found)*
- `npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_6848828632408331bf99e6d288343b7d