### PR TITLE
Update merge conflict guide

### DIFF
--- a/pullrequest_merge_conflict.md
+++ b/pullrequest_merge_conflict.md
@@ -8,8 +8,8 @@ This guide shows how to inspect open pull requests and compare them against the
 First add the repository fork as a remote and fetch all branches:
 
 ```bash
-# Replace <url> with the GitHub HTTPS or SSH URL
-git remote add upstream <url>
+# Add the original repository as the upstream remote
+git remote add upstream https://github.com/letapicode/YoutubeAutomation.git
 # Fetch all remote branches
 git fetch upstream
 ```
@@ -22,17 +22,17 @@ API with `curl`.
 ### Using `gh`
 
 ```bash
-# Requires the gh CLI and GH_TOKEN or GITHUB_TOKEN for authentication
+# Requires the gh CLI. Authentication is read from $GH_TOKEN or $GITHUB_TOKEN
 gh pr list --limit 20
 ```
 
 ### Using `curl`
 
 ```bash
-# Requires a GitHub token in $GH_TOKEN
-token="$GH_TOKEN"
-repo="owner/repo"
-curl -H "Authorization: Bearer $token" \ 
+# Reads the token from $GH_TOKEN or $GITHUB_TOKEN
+token="${GH_TOKEN:-$GITHUB_TOKEN}"
+repo="letapicode/YoutubeAutomation"
+curl -H "Authorization: Bearer $token" \
   "https://api.github.com/repos/$repo/pulls?state=open"
 ```
 


### PR DESCRIPTION
## Summary
- clarify GH token info
- use repo URL for the upstream remote
- show curl with repository variable set

## Testing
- `npm install` *(fails: 2 moderate vulnerabilities)*
- `cargo check` *(fails to compile)*
- `npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_6848a215b7588331ab099ccfd80d42cf