### PR TITLE
Add upload progress tracking

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -167,6 +167,7 @@
 * Generate & upload to YouTube button
 * Generation progress bar
 * Batch process progress UI
+* Upload progress bar
 * Drag & drop support for file inputs
 * Theme toggle (light/dark)
 * Accessible labels and full keyboard navigation
@@ -288,6 +289,8 @@ Upload an existing video with metadata:
 ```bash
 npx ts-node src/cli.ts upload video.mp4 --title "My Video"
 ```
+
+During uploads the CLI prints progress percentages similar to video generation.
 
 `--caption-color` and `--caption-bg` accept hex colors. You may also use the
 shorter `--color` and `--bg-color` aliases.

--- a/ytapp/src/components/BatchUploader.tsx
+++ b/ytapp/src/components/BatchUploader.tsx
@@ -28,15 +28,19 @@ const BatchUploader: React.FC = () => {
         for (const file of files) {
             prog[file] = 0;
             setProgressMap({ ...prog });
-            await uploadVideo({
-                file,
-                title: title || undefined,
-                description: description || undefined,
-                tags: tags ? tags.split(',').map(t => t.trim()).filter(Boolean) : undefined,
-                publishAt: publishDate ? new Date(publishDate).toISOString() : undefined,
-            });
-            prog[file] = 100;
-            setProgressMap({ ...prog });
+            await uploadVideo(
+                {
+                    file,
+                    title: title || undefined,
+                    description: description || undefined,
+                    tags: tags ? tags.split(',').map(t => t.trim()).filter(Boolean) : undefined,
+                    publishAt: publishDate ? new Date(publishDate).toISOString() : undefined,
+                },
+                (p) => {
+                    prog[file] = Math.round(p);
+                    setProgressMap({ ...prog });
+                },
+            );
         }
         setRunning(false);
     };

--- a/ytapp/tests/upload.test.ts
+++ b/ytapp/tests/upload.test.ts
@@ -1,0 +1,26 @@
+import assert from 'assert';
+import { uploadVideo } from '../src/features/youtube';
+const core = require('@tauri-apps/api/core');
+const events = require('@tauri-apps/api/event');
+
+core.invoke = async (cmd: string, args: any) => {
+  assert.strictEqual(cmd, 'upload_video');
+  assert.strictEqual(args.file, '/tmp/video.mp4');
+  return 'ok';
+};
+
+events.listen = async (name: string, handler: (e: any) => void) => {
+  assert.strictEqual(name, 'upload_progress');
+  handler({ payload: 0 });
+  handler({ payload: 50 });
+  handler({ payload: 100 });
+  return () => {};
+};
+
+(async () => {
+  let called = 0;
+  const res = await uploadVideo({ file: '/tmp/video.mp4' }, () => called++);
+  assert.strictEqual(res, 'ok');
+  assert.ok(called > 0);
+  console.log('upload tests passed');
+})();


### PR DESCRIPTION
## Summary
- emit `upload_progress` events from Tauri backend
- expose progress-capable upload helpers in TypeScript API
- show upload progress in CLI and batch uploader UI
- document upload progress in README
- test progress handling in upload API

## Testing
- `npm install`
- `cargo check` *(fails: gobject-2.0 not found)*
- `npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_6848e15c31e08331a3079b981d5cd177