### PR TITLE
Improve font detection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ cd .. && npx ts-node src/cli.ts --help
 ## Additional Notes
 - Do not commit `.env.tauri` or build artifacts.
 - Prefer cross-platform paths when invoking external tools.
+- System fonts are detected on all platforms; `fc-list` is optional on Linux.
 - To create release installers for all platforms, run `./scripts/package.sh`.
 - Language definitions live in `ytapp/src/features/languages/defs`. Add a new
   `<code>.json` file in that directory to support another language. Each file

--- a/readme.md
+++ b/readme.md
@@ -269,10 +269,11 @@ npm run start
 ### Custom Fonts
 
 Use the **Font** dropdown in the settings page to load any font installed on your
-system. If your font does not appear in the list, choose **Select File** to pick
-a `.ttf` or `.otf` file. The selected font and style are stored in the
-application settings and passed to FFmpeg so subtitles render with your custom
-font.
+system. Fonts are now detected on Windows, macOS and Linux by scanning the
+standard font folders (on Linux `fc-list` is used when available). If your font
+does not appear in the list, choose **Select File** to pick a `.ttf` or `.otf`
+file. The selected font and style are stored in the application settings and
+passed to FFmpeg so subtitles render with your custom font.
 
 ### CLI Usage
 

--- a/ytapp/src-tauri/Cargo.toml
+++ b/ytapp/src-tauri/Cargo.toml
@@ -18,6 +18,7 @@ chacha20poly1305 = { version = "0.10", features = ["std"] }
 rand_core = "0.6"
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
+walkdir = "2"
 
 [build-dependencies]
 tauri-build = "1"


### PR DESCRIPTION
## Summary
- scan Windows, macOS and Linux font folders for `.ttf`/`.otf`
- use fc-list on Linux when available
- add mocked tests for font detection
- document cross-platform font search

## Testing
- `npm install`
- `cargo check` *(fails: failed to compile ytapp)*
- `npx ts-node src/cli.ts --help`


------
https://chatgpt.com/codex/tasks/task_e_6848e7b49aa08331b596f91704d493a6