### PR TITLE
Add cancel support for generation and uploads

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -308,6 +308,7 @@ npx ts-node src/cli.ts upload video.mp4 --title "My Video"
 ```
 
 During uploads the CLI prints progress percentages similar to video generation.
+Press `Ctrl-C` at any time to cancel the current operation.
 
 `--caption-color` and `--caption-bg` accept hex colors. You may also use the
 shorter `--color` and `--bg-color` aliases.

--- a/ytapp/src-tauri/Cargo.toml
+++ b/ytapp/src-tauri/Cargo.toml
@@ -21,6 +21,7 @@ chrono = { version = "0.4", features = ["serde"] }
 walkdir = "2"
 notify = "8"
 once_cell = "1"
+futures = "0.3"
 
 [build-dependencies]
 tauri-build = "1"

--- a/ytapp/src/components/BatchProcessor.tsx
+++ b/ytapp/src/components/BatchProcessor.tsx
@@ -5,6 +5,7 @@ import FilePicker from './FilePicker';
 import { generateBatchWithProgress, BatchOptions } from '../features/batch';
 import { generateBatchUpload, generateUpload } from '../features/youtube';
 import { generateVideo } from '../features/processing';
+import { invoke } from '@tauri-apps/api/core';
 import BatchOptionsForm from './BatchOptionsForm';
 import UploadIcon from './UploadIcon';
 import { open } from '@tauri-apps/api/dialog';
@@ -72,6 +73,11 @@ const BatchProcessor: React.FC = () => {
     setRunning(false);
   };
 
+  const cancelBatch = async () => {
+    await invoke('cancel_generate');
+    setRunning(false);
+  };
+
   const startBatchUpload = async () => {
     if (!files.length) return;
     setUploading(true);
@@ -90,6 +96,11 @@ const BatchProcessor: React.FC = () => {
     } else {
       await generateBatchUpload({ files, ...options });
     }
+    setUploading(false);
+  };
+
+  const cancelUpload = async () => {
+    await invoke('cancel_upload');
     setUploading(false);
   };
 
@@ -116,6 +127,14 @@ const BatchProcessor: React.FC = () => {
         <div className="row">
           <progress value={progress} max={100} />
           <span>{progress}%</span>
+          <button onClick={cancelBatch}>{t('cancel')}</button>
+        </div>
+      )}
+      {uploading && (
+        <div className="row">
+          <progress value={progress} max={100} />
+          <span>{progress}%</span>
+          <button onClick={cancelUpload}>{t('cancel')}</button>
         </div>
       )}
     </div>

--- a/ytapp/tests/cancel.test.ts
+++ b/ytapp/tests/cancel.test.ts
@@ -1,0 +1,30 @@
+import assert from 'assert';
+const core = require('@tauri-apps/api/core');
+const events = require('@tauri-apps/api/event');
+
+(async () => {
+  let cancelCalled = false;
+  let rejectGen: (() => void) | null = null;
+  core.invoke = async (cmd: string) => {
+    if (cmd === 'generate_video') {
+      return new Promise((_r, rej) => { rejectGen = () => rej(new Error('canceled')); });
+    }
+    if (cmd === 'cancel_generate') {
+      cancelCalled = true;
+      if (rejectGen) rejectGen();
+    }
+  };
+  let handler: any;
+  events.listen = async (name: string, h: (e: any) => void) => {
+    if (name === 'generate_canceled') handler = h;
+    return () => {};
+  };
+  const { generateVideo } = await import('../src/features/processing');
+  const p = generateVideo({ file: 'a.mp3' }, undefined, () => { cancelCalled = true; }).catch(() => 'canceled');
+  await core.invoke('cancel_generate');
+  if (handler) handler({});
+  const res = await p;
+  assert.strictEqual(res, 'canceled');
+  assert.ok(cancelCalled);
+  console.log('cancel tests passed');
+})();


### PR DESCRIPTION
## Summary
- track running FFmpeg and uploads in backend
- allow cancelling video generation and uploads
- expose cancel commands to CLI and React frontend
- add cancel callbacks and buttons in UI
- handle Ctrl-C in CLI to abort operations
- document cancellation and add unit test

## Testing
- `npm install`
- `cargo check` *(fails: could not compile `ytapp`)*
- `npx ts-node src/cli.ts --help`
- `npx ts-node tests/csv.test.ts`
- `npx ts-node tests/upload.test.ts`
- `npx ts-node tests/cli_csv.test.ts`
- `npx ts-node tests/signout.test.ts`
- `npx ts-node tests/watch.test.ts`
- `npx ts-node tests/transcription.test.ts`
- `npx ts-node tests/cancel.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_684901e4d8848331a2cf771fcbd973fc