### PR TITLE
Update docs for install_tauri_deps.sh usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ cd .. && npx ts-node src/cli.ts --help
 ```
 
 `cargo check` may require system packages; run `./scripts/install_tauri_deps.sh` if needed.
+After running the script, source the generated `.env.tauri` file (or export the `PKG_CONFIG_PATH` it contains) before running cargo.
 
 ## Additional Notes
 - Do not commit `.env.tauri` or build artifacts.

--- a/readme.md
+++ b/readme.md
@@ -197,11 +197,14 @@
 
 ### Setup
 
-Run the helper script to install required system packages on Ubuntu/Debian:
+Run the helper script to install required system packages on Ubuntu/Debian.
+The script creates `.env.tauri` which sets `PKG_CONFIG_PATH`:
 
 ```bash
 ./scripts/install_tauri_deps.sh
+source .env.tauri   # sets PKG_CONFIG_PATH for cargo
 ```
+This prevents “glib-2.0” or similar errors when running `cargo check`.
 
 Install Tauri's system dependencies (Ubuntu/Debian):
 
@@ -225,7 +228,7 @@ sudo ln -s /usr/lib/x86_64-linux-gnu/pkgconfig/javascriptcoregtk-4.1.pc \
 ```
 
 `PKG_CONFIG_PATH` must include `/usr/lib/x86_64-linux-gnu/pkgconfig` when running
-`cargo check`. For example:
+`cargo check`. The install script places this value in `.env.tauri`. For example:
 
 ```bash
 export PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig


### PR DESCRIPTION
## Summary
- note to source `.env.tauri` after running install script in **AGENTS.md**
- document `.env.tauri` in the setup instructions and prevent glib errors

## Testing
- `npm install`
- `cargo check` *(fails: failed to read icon, unresolved imports, etc.)*
- `npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_68490b9ada18833181e10bc7a3707465