### PR TITLE
Add fromLang parameter to translateSrt

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -112,6 +112,7 @@
   * Maori
   * Gujarati
 * Output `.srt` file
+* Translations use the transcription language as the source when specified
 * Burn `.srt` captions into video using FFmpeg:
 
   * Font (user-selectable)

--- a/ytapp/src/cli.ts
+++ b/ytapp/src/cli.ts
@@ -140,14 +140,24 @@ async function uploadVideos(
 /**
  * Transcribe an audio file and optionally translate the subtitles.
  */
-async function transcribeAudio(params: { file: string; language?: string; translate?: string[] }): Promise<string[]> {
+async function transcribeAudio(params: {
+  file: string;
+  language?: string;
+  translate?: string[];
+}): Promise<string[]> {
   const { file, language = 'auto', translate } = params;
   const result: string = await invoke('transcribe_audio', { file, language });
   const outputs: string[] = [result];
   if (translate) {
     for (const t of translate) {
       try {
-        outputs.push(await translateSrt(result, t));
+        outputs.push(
+          await translateSrt(
+            result,
+            t,
+            language !== 'auto' ? language : 'en',
+          ),
+        );
       } catch {
         // ignore translation errors
       }

--- a/ytapp/src/features/transcription/index.ts
+++ b/ytapp/src/features/transcription/index.ts
@@ -26,7 +26,11 @@ export async function transcribeAudio(params: TranscribeParams): Promise<string[
     if (translate && Array.isArray(translate)) {
         for (const target of translate) {
             try {
-                const out = await translateSrt(result, target);
+                const out = await translateSrt(
+                    result,
+                    target,
+                    language !== 'auto' ? language : 'en',
+                );
                 outputs.push(out);
             } catch {
                 // ignore translation errors

--- a/ytapp/src/utils/translate.ts
+++ b/ytapp/src/utils/translate.ts
@@ -4,16 +4,20 @@
  */
 import { spawn } from 'child_process';
 
-export function translateSrt(input: string, target: string): Promise<string> {
+export function translateSrt(
+  input: string,
+  target: string,
+  fromLang = 'en',
+): Promise<string> {
   const output = input.replace(/\.srt$/, `.${target}.srt`);
   return new Promise((resolve, reject) => {
     const child = spawn('argos-translate', [
       '--input-file', input,
       '--output-file', output,
-      '--from-lang', 'en',
+      '--from-lang', fromLang,
       '--to-lang', target,
     ]);
-    child.on('exit', code => {
+    child.on('exit', (code) => {
       if (code === 0) resolve(output);
       else reject(new Error('translation failed'));
     });

--- a/ytapp/tests/translate.test.ts
+++ b/ytapp/tests/translate.test.ts
@@ -1,0 +1,24 @@
+import assert from 'assert';
+import { translateSrt } from '../src/utils/translate';
+const child = require('child_process');
+
+(async () => {
+  let called = false;
+  child.spawn = (cmd: string, args: string[]) => {
+    called = true;
+    assert.strictEqual(cmd, 'argos-translate');
+    const idx = args.indexOf('--from-lang');
+    assert.ok(idx >= 0);
+    assert.strictEqual(args[idx + 1], 'fr');
+    return {
+      on: (ev: string, cb: (code: number) => void) => {
+        if (ev === 'exit') setTimeout(() => cb(0), 0);
+      },
+    } as any;
+  };
+
+  const out = await translateSrt('/tmp/test.srt', 'es', 'fr');
+  assert.strictEqual(out, '/tmp/test.es.srt');
+  assert.ok(called);
+  console.log('translate tests passed');
+})();


### PR DESCRIPTION
## Summary
- allow specifying a source language when translating SRT files
- wire new parameter through transcription feature and CLI
- update documentation about translation behavior
- add unit test for argos-translate invocation

## Testing
- `npm install --no-fund --no-audit`
- `cargo check` *(fails: missing glib-2.0)*
- `npx ts-node src/cli.ts --help`
- `npx ts-node tests/csv.test.ts`
- `npx ts-node tests/upload.test.ts`
- `npx ts-node tests/translate.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68495399e33483319ec7798176e58e44