### PR TITLE
Update hyper imports

### DIFF
--- a/ytapp/src-tauri/src/main.rs
+++ b/ytapp/src-tauri/src/main.rs
@@ -13,8 +13,11 @@ use model_check::ensure_whisper_model;
 use google_youtube3::{api::Video, YouTube};
 use yup_oauth2::{InstalledFlowAuthenticator, InstalledFlowReturnMethod};
 use yup_oauth2::authenticator::Authenticator;
-use hyper_rustls::{HttpsConnectorBuilder, HttpsConnector};
-use hyper_util::{client::legacy::{Client, connect::HttpConnector}, rt::TokioExecutor};
+use google_youtube3::hyper_util::{
+    client::legacy::{Client, connect::HttpConnector},
+    rt::TokioExecutor,
+};
+use google_youtube3::hyper_rustls::{HttpsConnector, HttpsConnectorBuilder};
 use chrono::prelude::*;
 use walkdir::WalkDir;
 mod language;


### PR DESCRIPTION
## Summary
- use `google_youtube3` reexports of `hyper_util` and `hyper_rustls`
- prepare HTTP client using `TokioExecutor`

## Testing
- `npm install`
- `cargo check` *(fails: failed to read icon and other compile errors)*
- `npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_6849608ec4a8833196ace5c6ed7597fd