### PR TITLE
Add generate-batch CLI command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -311,13 +311,19 @@ Upload an existing video with metadata:
 npx ts-node src/cli.ts upload video.mp4 --title "My Video"
 ```
 
+Generate multiple videos without uploading:
+
+```bash
+npx ts-node src/cli.ts generate-batch a.wav b.wav -d ./out --title "Batch Title"
+```
+
 During uploads the CLI prints progress percentages similar to video generation.
 Press `Ctrl-C` at any time to cancel the current operation.
 
 `--caption-color` and `--caption-bg` accept hex colors. You may also use the
 shorter `--color` and `--bg-color` aliases.
 
-Batch commands (`generate-upload-batch` and `upload-batch`) accept `--csv <file>`
+Batch commands (`generate-batch`, `generate-upload-batch` and `upload-batch`) accept `--csv <file>`
 to provide per-file metadata. The CSV must contain `file,title,description,tags,publish_at`
 columns, where `tags` is a comma-separated list.
 

--- a/ytapp/tests/generate_batch_csv.test.ts
+++ b/ytapp/tests/generate_batch_csv.test.ts
@@ -1,0 +1,23 @@
+import assert from 'assert';
+import fs from 'fs/promises';
+const core = require('@tauri-apps/api/core');
+const events = require('@tauri-apps/api/event');
+
+(async () => {
+  const csv = '/tmp/generate_batch.csv';
+  await fs.writeFile(csv, 'file,title\na.mp3,FromCSV\n');
+  let called = false;
+  core.invoke = async (cmd: string, args: any) => {
+    called = true;
+    assert.strictEqual(cmd, 'generate_video');
+    assert.strictEqual(args.file, 'a.mp3');
+    assert.strictEqual(args.title, 'FromCSV');
+    return 'ok';
+  };
+  events.listen = async () => () => {};
+  process.argv = ['node', 'cli.ts', 'generate-batch', 'a.mp3', '--csv', csv];
+  await import('../src/cli');
+  await new Promise(r => setTimeout(r, 10));
+  assert.ok(called);
+  console.log('generate-batch csv test passed');
+})();


### PR DESCRIPTION
## Summary
- add `generate-batch` CLI command (alias `batch`)
- read per-file metadata from CSV when provided
- document new command and CSV usage
- test metadata mapping for `generate-batch`

## Testing
- `npm install`
- `npx ts-node tests/csv.test.ts`
- `npx ts-node tests/cli_csv.test.ts`
- `npx ts-node tests/generate_batch_csv.test.ts`
- `npx ts-node tests/upload.test.ts`
- `npx ts-node tests/signout.test.ts`
- `npx ts-node tests/cancel.test.ts`
- `npx ts-node tests/translate.test.ts`
- `npx ts-node tests/transcription.test.ts`
- `npx ts-node tests/watch.test.ts`
- `cargo check`
- `npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_68498f42ae84833184fcb4c511e56d6d