### PR TITLE
Fix tests that require Debug

### DIFF
--- a/ytapp/src-tauri/src/language.rs
+++ b/ytapp/src-tauri/src/language.rs
@@ -80,14 +80,14 @@ mod tests {
 
     #[test]
     fn parses_known_codes() {
-        assert_eq!(parse_language(Some("en".into())), Some(Language::English));
-        assert_eq!(parse_language(Some("ne".into())), Some(Language::Nepali));
+        assert!(matches!(parse_language(Some("en".into())), Some(Language::English)));
+        assert!(matches!(parse_language(Some("ne".into())), Some(Language::Nepali)));
     }
 
     #[test]
     fn handles_auto_and_unknown() {
-        assert_eq!(parse_language(Some("auto".into())), None);
-        assert_eq!(parse_language(Some("xx".into())), None);
-        assert_eq!(parse_language(None), None);
+        assert!(parse_language(Some("auto".into())).is_none());
+        assert!(parse_language(Some("xx".into())).is_none());
+        assert!(parse_language(None).is_none());
     }
 }


### PR DESCRIPTION
## Summary
- adjust language.rs tests so `Language` doesn't need `Debug`

## Testing
- `npm install`
- `cargo check`
- `npx ts-node src/cli.ts --help`


------
https://chatgpt.com/codex/tasks/task_e_68499006ccbc833188a8d0c37fb5498e