### PR TITLE
Add husky pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+. "$(dirname "$0")/_/husky.sh"
+
+cd ytapp && \
+npm run lint && \
+(cd src-tauri && cargo check --quiet) && \
+npx tsc --noEmit

--- a/ytapp/package-lock.json
+++ b/ytapp/package-lock.json
@@ -17,6 +17,7 @@
         "react-i18next": "^13.0.0"
       },
       "devDependencies": {
+        "husky": "^9.1.7",
         "ts-node": "^10.9.2",
         "typescript": "^4.0.0",
         "vite": "^4.0.0"
@@ -635,6 +636,22 @@
       "license": "MIT",
       "dependencies": {
         "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/i18next": {

--- a/ytapp/package.json
+++ b/ytapp/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "start": "vite",
     "build": "vite build",
-    "cli": "ts-node src/cli.ts"
+    "cli": "ts-node src/cli.ts",
+    "lint": "tsc --noEmit",
+    "prepare": "cd .. && npx husky install"
   },
   "dependencies": {
     "@tauri-apps/api": "^2.5.0",
@@ -19,6 +21,7 @@
   "devDependencies": {
     "ts-node": "^10.9.2",
     "typescript": "^4.0.0",
-    "vite": "^4.0.0"
+    "vite": "^4.0.0",
+    "husky": "^9.1.7"
   }
 }


### PR DESCRIPTION
## Summary
- add husky as a dev dependency
- ensure husky installs hooks from repository root
- run lint, cargo check and tsc in pre-commit hook

## Testing
- `cd ytapp && npm install`
- `./scripts/install_tauri_deps.sh`
- `cargo check`
- `npx ts-node src/cli.ts --help`


------
https://chatgpt.com/codex/tasks/task_e_6849c24df2888331871e8fdc0ba3045b