### PR TITLE
Update linting and pre-commit workflow

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -219,6 +219,7 @@ bootstrap script when first created.
 Pre-commit hooks should run the standard checks:
 ```bash
 cd ytapp && npm install
+npm run lint
 cd src-tauri && cargo check
 cd .. && npx ts-node src/cli.ts --help
 ```

--- a/ytapp/.husky/pre-commit
+++ b/ytapp/.husky/pre-commit
@@ -2,4 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 
 npm run lint || exit 1
-( cd src-tauri && cargo check --quiet ) || exit 1
+(cd src-tauri && cargo check --quiet) || exit 1

--- a/ytapp/package-lock.json
+++ b/ytapp/package-lock.json
@@ -17,6 +17,7 @@
         "react-i18next": "^13.0.0"
       },
       "devDependencies": {
+        "husky": "^9.1.7",
         "ts-node": "^10.9.2",
         "typescript": "^4.0.0",
         "vite": "^4.0.0"
@@ -635,6 +636,22 @@
       "license": "MIT",
       "dependencies": {
         "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/i18next": {

--- a/ytapp/package.json
+++ b/ytapp/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "start": "vite",
     "build": "vite build",
-    "cli": "ts-node src/cli.ts"
+    "cli": "ts-node src/cli.ts",
+    "lint": "tsc --noEmit",
+    "prepare": "cd .. && npx husky install"
   },
   "dependencies": {
     "@tauri-apps/api": "^2.5.0",
@@ -19,6 +21,7 @@
   "devDependencies": {
     "ts-node": "^10.9.2",
     "typescript": "^4.0.0",
-    "vite": "^4.0.0"
+    "vite": "^4.0.0",
+    "husky": "^9.1.7"
   }
 }


### PR DESCRIPTION
## Summary
- add lint and prepare scripts in ytapp `package.json`
- include husky as a dev dependency and regenerate lock file
- update pre-commit hook commands
- mention running `npm run lint` in README

## Testing
- `npm install`
- `cargo check --quiet` *(fails: gobject-2.0 missing)*
- `npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_6849d97980308331b53dd4027ccec84e