### PR TITLE
Implement job queue for ytapp

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -324,5 +324,23 @@ Watch a directory and automatically process new audio files:
 npx ts-node src/cli.ts watch ./incoming --auto-upload
 ```
 
+Queue up a file for later processing:
+
+```bash
+npx ts-node src/cli.ts queue-add input.wav --title "My Queued Video"
+```
+
+Show queued jobs:
+
+```bash
+npx ts-node src/cli.ts queue-list
+```
+
+Process all queued jobs:
+
+```bash
+npx ts-node src/cli.ts queue-run
+```
+
 
 

--- a/ytapp/public/locales/en/translation.json
+++ b/ytapp/public/locales/en/translation.json
@@ -60,4 +60,6 @@
   "not_watching": "Not Watching",
   "start_watch": "Start Watching",
   "stop_watch": "Stop Watching"
+  ,"queue": "Queue"
+  ,"process_queue": "Process Queue"
 }

--- a/ytapp/src-tauri/src/job_queue.rs
+++ b/ytapp/src-tauri/src/job_queue.rs
@@ -1,0 +1,64 @@
+use std::{fs, path::PathBuf};
+use once_cell::sync::Lazy;
+use std::sync::Mutex;
+use serde::{Serialize, Deserialize};
+use tauri::api::path::app_config_dir;
+
+use crate::schema::GenerateParams;
+
+#[derive(Serialize, Deserialize, Clone)]
+pub enum Job {
+    Generate { params: GenerateParams, dest: String },
+    GenerateUpload { params: GenerateParams, dest: String },
+}
+
+static QUEUE: Lazy<Mutex<Vec<Job>>> = Lazy::new(|| Mutex::new(Vec::new()));
+
+fn queue_path(app: &tauri::AppHandle) -> Result<PathBuf, String> {
+    let mut dir = app_config_dir(&app.config()).ok_or("config dir not found")?;
+    fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    dir.push("queue.json");
+    Ok(dir)
+}
+
+pub fn enqueue(app: &tauri::AppHandle, job: Job) -> Result<(), String> {
+    let mut q = QUEUE.lock().unwrap();
+    q.push(job);
+    save_queue(app)
+}
+
+pub fn dequeue(app: &tauri::AppHandle) -> Result<Option<Job>, String> {
+    let mut q = QUEUE.lock().unwrap();
+    let job = if q.is_empty() { None } else { Some(q.remove(0)) };
+    if job.is_some() { save_queue(app)?; }
+    Ok(job)
+}
+
+pub fn peek_all() -> Vec<Job> {
+    let q = QUEUE.lock().unwrap();
+    q.clone()
+}
+
+pub fn save_queue(app: &tauri::AppHandle) -> Result<(), String> {
+    let path = queue_path(app)?;
+    let q = QUEUE.lock().unwrap();
+    let data = serde_json::to_string(&*q).map_err(|e| e.to_string())?;
+    fs::write(path, data).map_err(|e| e.to_string())
+}
+
+pub fn load_queue(app: &tauri::AppHandle) -> Result<(), String> {
+    let path = queue_path(app)?;
+    let data = match fs::read_to_string(&path) {
+        Ok(d) => d,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            let mut q = QUEUE.lock().unwrap();
+            q.clear();
+            return Ok(());
+        }
+        Err(e) => return Err(e.to_string()),
+    };
+    let q_data: Vec<Job> = serde_json::from_str(&data).map_err(|e| e.to_string())?;
+    let mut q = QUEUE.lock().unwrap();
+    *q = q_data;
+    Ok(())
+}

--- a/ytapp/src-tauri/src/schema.rs
+++ b/ytapp/src-tauri/src/schema.rs
@@ -1,6 +1,6 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Clone, Default)]
+#[derive(Serialize, Deserialize, Clone, Default)]
 pub struct CaptionOptions {
     pub font: Option<String>,
     #[serde(rename = "fontPath")]
@@ -12,7 +12,7 @@ pub struct CaptionOptions {
     pub background: Option<String>,
 }
 
-#[derive(Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct GenerateParams {
     pub file: String,
     pub output: Option<String>,

--- a/ytapp/src/components/WatchStatus.tsx
+++ b/ytapp/src/components/WatchStatus.tsx
@@ -3,18 +3,24 @@ import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { loadSettings } from '../features/settings';
 import { watchDirectory } from '../features/watch';
+import { listJobs, runQueue } from '../features/queue';
 
 const WatchStatus: React.FC = () => {
     const { t } = useTranslation();
     const [watching, setWatching] = useState(false);
     const [dir, setDir] = useState('');
     const [auto, setAuto] = useState(false);
+    const [queueLen, setQueueLen] = useState(0);
 
     useEffect(() => {
         loadSettings().then(s => {
             setDir(s.watchDir || '');
             setAuto(!!s.autoUpload);
         });
+        const interval = setInterval(() => {
+            listJobs().then(j => setQueueLen(j.length));
+        }, 1000);
+        return () => clearInterval(interval);
     }, []);
 
     const toggle = async () => {
@@ -27,12 +33,18 @@ const WatchStatus: React.FC = () => {
         }
     };
 
+    const process = async () => {
+        await runQueue();
+    };
+
     return (
         <div>
             <span>{watching ? t('watching') : t('not_watching')}</span>
             <button onClick={toggle}>
                 {watching ? t('stop_watch') : t('start_watch')}
             </button>
+            <span> {t('queue')}: {queueLen}</span>
+            <button onClick={process}>{t('process_queue')}</button>
         </div>
     );
 };

--- a/ytapp/src/features/queue.ts
+++ b/ytapp/src/features/queue.ts
@@ -1,0 +1,18 @@
+import { invoke } from '@tauri-apps/api/core';
+import { GenerateParams } from './processing';
+
+export type QueueJob =
+  | { Generate: { params: GenerateParams; dest: string } }
+  | { GenerateUpload: { params: GenerateParams; dest: string } };
+
+export async function addJob(job: QueueJob): Promise<void> {
+  await invoke('queue_add', { job });
+}
+
+export async function listJobs(): Promise<QueueJob[]> {
+  return await invoke('queue_list');
+}
+
+export async function runQueue(): Promise<void> {
+  await invoke('queue_process');
+}

--- a/ytapp/tests/cli_queue.test.ts
+++ b/ytapp/tests/cli_queue.test.ts
@@ -1,0 +1,18 @@
+import assert from 'assert';
+const core = require('@tauri-apps/api/core');
+const events = require('@tauri-apps/api/event');
+
+(async () => {
+  let called = '';
+  core.invoke = async (cmd: string, args: any) => {
+    called = cmd;
+    if (cmd === 'queue_add') {
+      assert.strictEqual(args.job.GenerateUpload.params.file, 'a.mp3');
+    }
+  };
+  events.listen = async () => () => {};
+  process.argv = ['node', 'cli.ts', 'queue-add', 'a.mp3'];
+  await import('../src/cli');
+  assert.strictEqual(called, 'queue_add');
+  console.log('cli queue tests passed');
+})();

--- a/ytapp/tests/queue.test.ts
+++ b/ytapp/tests/queue.test.ts
@@ -1,0 +1,19 @@
+import assert from 'assert';
+const core = require('@tauri-apps/api/core');
+
+(async () => {
+  let q: any[] = [];
+  core.invoke = async (cmd: string, args: any) => {
+    if (cmd === 'queue_add') { q.push(args.job); return; }
+    if (cmd === 'queue_list') { return q; }
+    if (cmd === 'queue_process') { q = []; return; }
+  };
+  const { addJob, listJobs, runQueue } = await import('../src/features/queue');
+  await addJob({ Generate: { params: { file: 'a.mp3' }, dest: 'a.mp4' } } as any);
+  let jobs = await listJobs();
+  assert.strictEqual(jobs.length, 1);
+  await runQueue();
+  jobs = await listJobs();
+  assert.strictEqual(jobs.length, 0);
+  console.log('queue feature tests passed');
+})();


### PR DESCRIPTION
## Summary
- add job queue module in Rust storing jobs on disk
- enqueue new files in watcher instead of processing immediately
- expose queue manipulation commands to Tauri
- add TypeScript wrappers and CLI commands for queue
- display queue length and "Process Queue" button in `WatchStatus`
- document queue usage in README
- provide tests for queue features and CLI

## Testing
- `cd ytapp && npm install`
- `cd src-tauri && cargo check`
- `cd ../.. && npx ts-node src/cli.ts --help`
- `cd ytapp && npx -y ts-node tests/queue.test.ts`
- `cd ytapp && npx -y ts-node tests/cli_queue.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6849ed13fcb083318ee0e0458d32b267