### PR TITLE
Fix React typings and TypeScript config

### DIFF
--- a/ytapp/package-lock.json
+++ b/ytapp/package-lock.json
@@ -22,6 +22,7 @@
         "@types/node": "^20.0.0",
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
+        "@types/react-dropzone": "^5.1.0",
         "husky": "^9.1.7",
         "ts-node": "^10.9.2",
         "typescript": "^4.0.0",
@@ -544,6 +545,17 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/react-dropzone": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/react-dropzone/-/react-dropzone-5.1.0.tgz",
+      "integrity": "sha512-VCdDCwSsr1MT2frsVl5p8qH+LWwUGzsaNtGkEQekHviZqK0dmTbiIp2Pzfb8lTkH4oTE2JtBbWnbuM6B4FH80A==",
+      "deprecated": "This is a stub types definition. react-dropzone provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-dropzone": "*"
       }
     },
     "node_modules/acorn": {

--- a/ytapp/package.json
+++ b/ytapp/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
+    "@types/react-dropzone": "^5.1.0",
     "@types/node": "^20.0.0",
     "husky": "^9.1.7",
     "ts-node": "^10.9.2",

--- a/ytapp/src/vite-env.d.ts
+++ b/ytapp/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/ytapp/tsconfig.json
+++ b/ytapp/tsconfig.json
@@ -11,6 +11,7 @@
     "resolveJsonModule": true
   },
   "include": [
-    "src/**/*"
+    "src/**/*",
+    "src/vite-env.d.ts"
   ]
 }


### PR DESCRIPTION
## Summary
- add `@types/react-dropzone` dev dependency
- include `vite-env.d.ts` and update tsconfig

## Testing
- `npm run lint`
- `cargo check`
- `npx ts-node --compiler-options '{"module":"CommonJS"}' src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_6849fa45bbc883318d6c5b8eba5ac638