### PR TITLE
Add Whisper model size configuration

### DIFF
--- a/ytapp/public/locales/en/translation.json
+++ b/ytapp/public/locales/en/translation.json
@@ -38,6 +38,7 @@
   "advanced_settings": "Advanced Settings",
   "caption_color": "Caption Color",
   "caption_bg": "Caption Background",
+  "whisper_size": "Whisper Model Size",
   "watermark": "Watermark",
   "watermark_position": "Watermark Position",
   "top_left": "Top Left",

--- a/ytapp/src-tauri/src/model_check.rs
+++ b/ytapp/src-tauri/src/model_check.rs
@@ -1,9 +1,36 @@
+use std::fs;
+use serde::Deserialize;
+use serde_json;
+use tauri::api::path::app_config_dir;
+use tauri::Config;
 use whisper_cli::{Model, Size};
 
 /// Ensure the default Whisper model is present. Downloads it if missing.
-pub fn ensure_whisper_model() {
+#[derive(Deserialize)]
+struct PartialSettings {
+    model_size: Option<String>,
+}
+
+pub fn ensure_whisper_model(config: &Config) {
+    let size = read_size(config).unwrap_or(Size::Base);
     tauri::async_runtime::block_on(async {
-        // download() is a no-op when the model already exists
-        Model::new(Size::Base).download().await;
+        let model = Model::new(size);
+        if !model.get_path().exists() {
+            model.download().await;
+        }
     });
+}
+
+fn read_size(config: &Config) -> Option<Size> {
+    let mut path = app_config_dir(config)?;
+    path.push("settings.json");
+    let data = fs::read_to_string(path).ok()?;
+    let s: PartialSettings = serde_json::from_str(&data).ok()?;
+    match s.model_size.as_deref()? {
+        "tiny" => Some(Size::Tiny),
+        "small" => Some(Size::Small),
+        "medium" => Some(Size::Medium),
+        "large" => Some(Size::Large),
+        _ => Some(Size::Base),
+    }
 }

--- a/ytapp/src/cli.ts
+++ b/ytapp/src/cli.ts
@@ -135,9 +135,10 @@ async function transcribeAudio(params: {
   file: string;
   language?: string;
   translate?: string[];
+  modelSize?: string;
 }): Promise<string[]> {
-  const { file, language = 'auto', translate } = params;
-  const result: string = await invoke('transcribe_audio', { file, language });
+  const { file, language = 'auto', translate, modelSize } = params;
+  const result: string = await invoke('transcribe_audio', { file, language, size: modelSize });
   const outputs: string[] = [result];
   if (translate) {
     for (const t of translate) {
@@ -794,6 +795,7 @@ program
   .description('Transcribe audio to SRT')
   .argument('<file>', 'audio file path')
   .option('-l, --language <lang>', 'language code (auto|ne|hi|en)', 'auto')
+  .option('-m, --model-size <size>', 'Whisper model size (tiny|base|small|medium|large)', 'base')
   // Specify one or more target language codes using multiple -t options
   .option('-t, --translate <lang...>', 'translate subtitles to languages')
   .action(async (file: string, options: any) => {
@@ -801,6 +803,7 @@ program
       const results = await transcribeAudio({
         file,
         language: options.language,
+        modelSize: options.modelSize,
         translate: options.translate,
       });
       results.forEach(r => console.log(r));

--- a/ytapp/src/components/SettingsPage.tsx
+++ b/ytapp/src/components/SettingsPage.tsx
@@ -22,6 +22,7 @@ const SettingsPage: React.FC = () => {
     const [guide, setGuide] = useState(true);
     const [watchDir, setWatchDir] = useState('');
     const [autoUpload, setAutoUpload] = useState(false);
+    const [modelSize, setModelSize] = useState('base');
 
     useEffect(() => {
         loadSettings().then(s => {
@@ -39,6 +40,7 @@ const SettingsPage: React.FC = () => {
             setGuide(s.showGuide !== false);
             setWatchDir(s.watchDir || '');
             setAutoUpload(!!s.autoUpload);
+            if (s.modelSize) setModelSize(s.modelSize);
         });
     }, []);
 
@@ -58,6 +60,7 @@ const SettingsPage: React.FC = () => {
             showGuide: guide,
             watchDir: watchDir || undefined,
             autoUpload,
+            modelSize,
         });
     };
 
@@ -136,6 +139,16 @@ const SettingsPage: React.FC = () => {
                 <input type="color" value={captionColor} onChange={e => setCaptionColor(e.target.value)} />
                 <label>{t('caption_bg')}</label>
                 <input type="color" value={captionBg} onChange={e => setCaptionBg(e.target.value)} />
+            </div>
+            <div>
+                <label>{t('whisper_size')}</label>
+                <select value={modelSize} onChange={e => setModelSize(e.target.value)}>
+                    <option value="tiny">tiny</option>
+                    <option value="base">base</option>
+                    <option value="small">small</option>
+                    <option value="medium">medium</option>
+                    <option value="large">large</option>
+                </select>
             </div>
             <div>
                 <label>{t('watch_directory')}</label>

--- a/ytapp/src/components/TranscribeButton.tsx
+++ b/ytapp/src/components/TranscribeButton.tsx
@@ -1,8 +1,9 @@
 // Button that transcribes audio to SRT and optionally translates it.
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { transcribeAudio } from '../features/transcription';
 import { Language } from '../features/language';
+import { loadSettings } from '../features/settings';
 
 interface TranscribeButtonProps {
     file: string;
@@ -18,13 +19,20 @@ const TranscribeButton: React.FC<TranscribeButtonProps> = ({ file, language, tar
     const { t } = useTranslation();
     const [running, setRunning] = useState(false);
     const [error, setError] = useState<string | null>(null);
+    const [modelSize, setModelSize] = useState('base');
+
+    useEffect(() => {
+        loadSettings().then(s => {
+            if (s.modelSize) setModelSize(s.modelSize);
+        });
+    }, []);
 
     const handleClick = async () => {
         if (!file) return;
         setRunning(true);
         setError(null);
         try {
-            const result = await transcribeAudio({ file, language, translate: targets });
+            const result = await transcribeAudio({ file, language, translate: targets, modelSize });
             onComplete(result);
         } catch (err: any) {
             setError(String(err));

--- a/ytapp/src/features/settings/index.ts
+++ b/ytapp/src/features/settings/index.ts
@@ -16,6 +16,7 @@ export interface Settings {
     showGuide?: boolean;
     watchDir?: string;
     autoUpload?: boolean;
+    modelSize?: string;
 }
 
 export async function loadSettings(): Promise<Settings> {

--- a/ytapp/src/features/transcription/index.ts
+++ b/ytapp/src/features/transcription/index.ts
@@ -10,6 +10,7 @@ export interface TranscribeParams {
      * Target language codes to translate the generated SRT file.
      */
     translate?: string[];
+    modelSize?: string;
 }
 
 /**
@@ -20,8 +21,8 @@ export interface TranscribeParams {
  * @returns Array of generated subtitle paths.
  */
 export async function transcribeAudio(params: TranscribeParams): Promise<string[]> {
-    const { file, language = 'auto', translate } = params;
-    const result: string = await invoke('transcribe_audio', { file, language });
+    const { file, language = 'auto', translate, modelSize } = params;
+    const result: string = await invoke('transcribe_audio', { file, language, size: modelSize });
     const outputs: string[] = [result];
     if (translate && Array.isArray(translate)) {
         for (const target of translate) {


### PR DESCRIPTION
## Summary
- let users choose Whisper model size from CLI and settings
- load selected model in model_check and download if missing
- honor configured size when transcribing audio

## Testing
- `cd ytapp && npm install`
- `cd src-tauri && cargo check`
- `cd .. && npx ts-node src/cli.ts --help`


------
https://chatgpt.com/codex/tasks/task_e_684a1f4b3a4c8331a48f48fe10b9c95e