### PR TITLE
Enable auto queue processing

### DIFF
--- a/ytapp/src/components/WatchStatus.tsx
+++ b/ytapp/src/components/WatchStatus.tsx
@@ -44,7 +44,7 @@ const WatchStatus: React.FC = () => {
                 {watching ? t('stop_watch') : t('start_watch')}
             </button>
             <span> {t('queue')}: {queueLen}</span>
-            <button onClick={process}>{t('process_queue')}</button>
+            {!auto && <button onClick={process}>{t('process_queue')}</button>}
         </div>
     );
 };


### PR DESCRIPTION
## Summary
- notify background worker whenever jobs are enqueued
- wake queue worker via `tokio::sync::Notify`
- ensure worker starts when directory watching begins
- hide "Process Queue" when auto-processing is on

## Testing
- `npm install`
- `cargo check`
- `npx ts-node src/cli.ts --help`


------
https://chatgpt.com/codex/tasks/task_e_684a1f37d58c833193c9a55754814859