### PR TITLE
Implement queue clear functionality

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -337,6 +337,12 @@ Show queued jobs:
 npx ts-node src/cli.ts queue-list
 ```
 
+Clear the queue:
+
+```bash
+npx ts-node src/cli.ts queue-clear
+```
+
 Process all queued jobs:
 
 ```bash

--- a/ytapp/src-tauri/src/job_queue.rs
+++ b/ytapp/src-tauri/src/job_queue.rs
@@ -69,3 +69,10 @@ pub fn load_queue(app: &tauri::AppHandle) -> Result<(), String> {
     *q = q_data;
     Ok(())
 }
+
+/// Remove all queued jobs and persist the empty queue.
+pub fn clear_queue(app: &tauri::AppHandle) -> Result<(), String> {
+    let mut q = QUEUE.lock().unwrap();
+    q.clear();
+    save_queue(app)
+}

--- a/ytapp/src-tauri/src/main.rs
+++ b/ytapp/src-tauri/src/main.rs
@@ -28,7 +28,7 @@ mod language;
 mod token_store;
 use token_store::EncryptedTokenStorage;
 mod job_queue;
-use job_queue::{Job, enqueue, dequeue, peek_all, load_queue, notifier};
+use job_queue::{Job, enqueue, dequeue, peek_all, load_queue, clear_queue as clear_in_memory, notifier};
 use tauri::api::dialog::{blocking::MessageDialogBuilder, MessageDialogKind};
 use notify::{RecommendedWatcher, RecursiveMode, Watcher, Config, EventKind, Event, Error as NotifyError};
 use once_cell::sync::Lazy;
@@ -855,6 +855,12 @@ fn queue_list(app: tauri::AppHandle) -> Result<Vec<Job>, String> {
 }
 
 #[command]
+fn queue_clear(app: tauri::AppHandle) -> Result<(), String> {
+    load_queue(&app).ok();
+    clear_in_memory(&app)
+}
+
+#[command]
 async fn queue_process(window: Window) -> Result<(), String> {
     let app = window.app_handle();
     load_queue(&app).ok();
@@ -1138,7 +1144,7 @@ fn main() {
             }
             Ok(())
         })
-        .invoke_handler(tauri::generate_handler![generate_video, upload_video, upload_videos, transcribe_audio, generate_upload, generate_batch_upload, watch_directory, youtube_sign_in, youtube_sign_out, youtube_is_signed_in, load_settings, save_settings, load_srt, save_srt, cancel_generate, cancel_upload, queue_add, queue_list, queue_process, profile_list, profile_get, profile_save, profile_delete, verify_dependencies, install_tauri_deps, list_fonts])
+        .invoke_handler(tauri::generate_handler![generate_video, upload_video, upload_videos, transcribe_audio, generate_upload, generate_batch_upload, watch_directory, youtube_sign_in, youtube_sign_out, youtube_is_signed_in, load_settings, save_settings, load_srt, save_srt, cancel_generate, cancel_upload, queue_add, queue_list, queue_clear, queue_process, profile_list, profile_get, profile_save, profile_delete, verify_dependencies, install_tauri_deps, list_fonts])
         .run(context)
         .expect("error while running tauri application");
 }

--- a/ytapp/src/cli.ts
+++ b/ytapp/src/cli.ts
@@ -11,7 +11,7 @@ import { translateSrt } from './utils/translate';
 import { parseCsv, CsvRow } from './utils/csv';
 import { watchDirectory } from './features/watch';
 import { generateBatchWithProgress } from './features/batch';
-import { addJob, listJobs, runQueue } from './features/queue';
+import { addJob, listJobs, runQueue, clearQueue } from './features/queue';
 import { listProfiles, getProfile, saveProfile, deleteProfile } from './features/profiles';
 import type { Profile } from './schema';
 
@@ -891,6 +891,18 @@ program
       console.log(JSON.stringify(jobs, null, 2));
     } catch (err) {
       console.error('Error listing queue:', err);
+      process.exitCode = 1;
+    }
+  });
+
+program
+  .command('queue-clear')
+  .description('Remove all jobs from the queue')
+  .action(async () => {
+    try {
+      await clearQueue();
+    } catch (err) {
+      console.error('Error clearing queue:', err);
       process.exitCode = 1;
     }
   });

--- a/ytapp/src/features/queue.ts
+++ b/ytapp/src/features/queue.ts
@@ -13,6 +13,11 @@ export async function listJobs(): Promise<QueueJob[]> {
   return await invoke('queue_list');
 }
 
+/** Clear all jobs from the queue. */
+export async function clearQueue(): Promise<void> {
+  await invoke('queue_clear');
+}
+
 export async function runQueue(): Promise<void> {
   await invoke('queue_process');
 }


### PR DESCRIPTION
## Summary
- implement `clear_queue` in Rust backend
- expose new `queue_clear` command via Tauri
- add TypeScript helpers and CLI wrapper for clearing the queue
- document `queue-clear` usage in README

## Testing
- `npm install`
- `cargo check`
- `npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_684b49b1d17c8331ab9795215a0b01ca