### PR TITLE
Enhance queue with retry logic

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -336,6 +336,8 @@ Show queued jobs:
 ```bash
 npx ts-node src/cli.ts queue-list
 ```
+Each job now tracks a `status` and `retries` count in `queue.json`.
+Failed jobs remain in the queue until they succeed or exceed the retry limit.
 
 Clear the queue:
 
@@ -343,11 +345,12 @@ Clear the queue:
 npx ts-node src/cli.ts queue-clear
 ```
 
-Process all queued jobs:
+Process all queued jobs (retry failed jobs with `--retry-failed`):
 
 ```bash
-npx ts-node src/cli.ts queue-run
+npx ts-node src/cli.ts queue-run --retry-failed
 ```
+The maximum retry count is configured by `max_retries` in `settings.json` (default `3`).
 
 Profiles can store commonly used generation options in `settings.json`.
 Save a profile from a JSON file:

--- a/ytapp/src-tauri/src/job_queue.rs
+++ b/ytapp/src-tauri/src/job_queue.rs
@@ -7,13 +7,29 @@ use tauri::api::path::app_config_dir;
 
 use crate::schema::GenerateParams;
 
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
+pub enum JobStatus {
+    Pending,
+    Running,
+    Failed,
+    Completed,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct QueueItem {
+    pub job: Job,
+    pub status: JobStatus,
+    pub retries: u32,
+    pub error: Option<String>,
+}
+
 #[derive(Serialize, Deserialize, Clone)]
 pub enum Job {
     Generate { params: GenerateParams, dest: String },
     GenerateUpload { params: GenerateParams, dest: String, thumbnail: Option<String> },
 }
 
-static QUEUE: Lazy<Mutex<Vec<Job>>> = Lazy::new(|| Mutex::new(Vec::new()));
+static QUEUE: Lazy<Mutex<Vec<QueueItem>>> = Lazy::new(|| Mutex::new(Vec::new()));
 static NOTIFY: Lazy<Arc<Notify>> = Lazy::new(|| Arc::new(Notify::new()));
 
 pub fn notifier() -> Arc<Notify> {
@@ -21,6 +37,12 @@ pub fn notifier() -> Arc<Notify> {
 }
 
 fn queue_path(app: &tauri::AppHandle) -> Result<PathBuf, String> {
+    if let Ok(p) = std::env::var("YTAPP_TEST_DIR") {
+        let mut dir = PathBuf::from(p);
+        fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+        dir.push("queue.json");
+        return Ok(dir);
+    }
     let mut dir = app_config_dir(&app.config()).ok_or("config dir not found")?;
     fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
     dir.push("queue.json");
@@ -29,19 +51,43 @@ fn queue_path(app: &tauri::AppHandle) -> Result<PathBuf, String> {
 
 pub fn enqueue(app: &tauri::AppHandle, job: Job) -> Result<(), String> {
     let mut q = QUEUE.lock().unwrap();
-    q.push(job);
+    q.push(QueueItem { job, status: JobStatus::Pending, retries: 0, error: None });
     NOTIFY.notify_one();
     save_queue(app)
 }
 
-pub fn dequeue(app: &tauri::AppHandle) -> Result<Option<Job>, String> {
+pub fn dequeue(app: &tauri::AppHandle, retry_failed: bool, max_retries: u32) -> Result<Option<(usize, QueueItem)>, String> {
     let mut q = QUEUE.lock().unwrap();
-    let job = if q.is_empty() { None } else { Some(q.remove(0)) };
-    if job.is_some() { save_queue(app)?; }
-    Ok(job)
+    for (i, item) in q.iter_mut().enumerate() {
+        if item.status == JobStatus::Pending ||
+           (retry_failed && item.status == JobStatus::Failed && item.retries < max_retries) {
+            item.status = JobStatus::Running;
+            save_queue(app)?;
+            return Ok(Some((i, item.clone())));
+        }
+    }
+    Ok(None)
 }
 
-pub fn peek_all() -> Vec<Job> {
+pub fn mark_complete(app: &tauri::AppHandle, index: usize) -> Result<(), String> {
+    let mut q = QUEUE.lock().unwrap();
+    if index < q.len() {
+        q.remove(index);
+    }
+    save_queue(app)
+}
+
+pub fn mark_failed(app: &tauri::AppHandle, index: usize, error: String) -> Result<(), String> {
+    let mut q = QUEUE.lock().unwrap();
+    if let Some(item) = q.get_mut(index) {
+        item.status = JobStatus::Failed;
+        item.retries += 1;
+        item.error = Some(error);
+    }
+    save_queue(app)
+}
+
+pub fn peek_all() -> Vec<QueueItem> {
     let q = QUEUE.lock().unwrap();
     q.clone()
 }
@@ -64,7 +110,13 @@ pub fn load_queue(app: &tauri::AppHandle) -> Result<(), String> {
         }
         Err(e) => return Err(e.to_string()),
     };
-    let q_data: Vec<Job> = serde_json::from_str(&data).map_err(|e| e.to_string())?;
+    let q_data: Vec<QueueItem> = match serde_json::from_str(&data) {
+        Ok(v) => v,
+        Err(_) => {
+            let legacy: Vec<Job> = serde_json::from_str(&data).map_err(|e| e.to_string())?;
+            legacy.into_iter().map(|job| QueueItem { job, status: JobStatus::Pending, retries: 0, error: None }).collect()
+        }
+    };
     let mut q = QUEUE.lock().unwrap();
     *q = q_data;
     Ok(())
@@ -75,4 +127,26 @@ pub fn clear_queue(app: &tauri::AppHandle) -> Result<(), String> {
     let mut q = QUEUE.lock().unwrap();
     q.clear();
     save_queue(app)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tauri::test::mock_app;
+
+    #[test]
+    fn persist_and_retry() {
+        let dir = tempfile::tempdir().unwrap();
+        std::env::set_var("YTAPP_TEST_DIR", dir.path());
+        let app = mock_app();
+        let params = GenerateParams { file: "a.mp3".into(), output: None, captions: None, caption_options: None, background: None, intro: None, outro: None, watermark: None, watermark_position: None, width: None, height: None, title: None, description: None, tags: None, publish_at: None, thumbnail: None };
+        enqueue(&app.handle(), Job::Generate { params: params.clone(), dest: "a.mp4".into() }).unwrap();
+        load_queue(&app.handle()).unwrap();
+        assert_eq!(peek_all().len(), 1);
+        mark_failed(&app.handle(), 0, "err".into()).unwrap();
+        load_queue(&app.handle()).unwrap();
+        let item = peek_all()[0].clone();
+        assert_eq!(item.retries, 1);
+        assert_eq!(item.status, JobStatus::Failed);
+    }
 }

--- a/ytapp/src/cli.ts
+++ b/ytapp/src/cli.ts
@@ -910,9 +910,10 @@ program
 program
   .command('queue-run')
   .description('Process queued jobs')
-  .action(async () => {
+  .option('--retry-failed', 'retry previously failed jobs')
+  .action(async (opts: any) => {
     try {
-      await runQueue();
+      await runQueue(!!opts.retryFailed);
     } catch (err) {
       console.error('Error running queue:', err);
       process.exitCode = 1;

--- a/ytapp/src/features/queue.ts
+++ b/ytapp/src/features/queue.ts
@@ -5,11 +5,18 @@ export type QueueJob =
   | { Generate: { params: GenerateParams; dest: string } }
   | { GenerateUpload: { params: GenerateParams; dest: string; thumbnail?: string } };
 
+export interface QueueItem {
+  job: QueueJob;
+  status: 'pending' | 'running' | 'failed' | 'completed';
+  retries: number;
+  error?: string;
+}
+
 export async function addJob(job: QueueJob): Promise<void> {
   await invoke('queue_add', { job });
 }
 
-export async function listJobs(): Promise<QueueJob[]> {
+export async function listJobs(): Promise<QueueItem[]> {
   return await invoke('queue_list');
 }
 
@@ -18,6 +25,6 @@ export async function clearQueue(): Promise<void> {
   await invoke('queue_clear');
 }
 
-export async function runQueue(): Promise<void> {
-  await invoke('queue_process');
+export async function runQueue(retryFailed = false): Promise<void> {
+  await invoke('queue_process', { retryFailed });
 }

--- a/ytapp/tests/queue.test.ts
+++ b/ytapp/tests/queue.test.ts
@@ -4,7 +4,7 @@ const core = require('@tauri-apps/api/core');
 (async () => {
   let q: any[] = [];
   core.invoke = async (cmd: string, args: any) => {
-    if (cmd === 'queue_add') { q.push(args.job); return; }
+    if (cmd === 'queue_add') { q.push({ job: args.job, status: 'pending', retries: 0 }); return; }
     if (cmd === 'queue_list') { return q; }
     if (cmd === 'queue_process') { q = []; return; }
   };


### PR DESCRIPTION
## Summary
- add `QueueItem` structure with status and retry count
- persist queue items and allow marking complete or failed
- update worker and CLI to retry failed jobs via `--retry-failed`
- expose queue item status in TypeScript API
- document queue status fields and retry flag in README
- test queue feature updates in TS and Rust

## Testing
- `npm install`
- `cargo check` *(fails: gobject-2.0 and glib-2.0 not found)*
- `npx ts-node src/cli.ts --help`
- `npx ts-node tests/queue.test.ts`
- `npx ts-node tests/cli_queue.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_684b43190b888331baface6f19dbca20