### PR TITLE
Fix queue upload return type

### DIFF
--- a/ytapp/src-tauri/src/main.rs
+++ b/ytapp/src-tauri/src/main.rs
@@ -890,7 +890,7 @@ async fn queue_process(window: Window, retry_failed: Option<bool>) -> Result<(),
             Job::GenerateUpload { mut params, dest, thumbnail } => {
                 params.output = Some(dest);
                 if params.thumbnail.is_none() { params.thumbnail = thumbnail.clone(); }
-                generate_upload(window.clone(), params).await.map(|_| ())
+                generate_upload(window.clone(), params).await
             }
         };
         match res {
@@ -922,7 +922,7 @@ fn start_queue_worker(window: Window) {
                     Job::GenerateUpload { mut params, dest, thumbnail } => {
                         params.output = Some(dest);
                         if params.thumbnail.is_none() { params.thumbnail = thumbnail.clone(); }
-                        generate_upload(window.clone(), params).await.map(|_| ())
+                        generate_upload(window.clone(), params).await
                     }
                 };
                 match res {


### PR DESCRIPTION
## Summary
- propagate return value from `generate_upload`

## Testing
- `scripts/install_tauri_deps.sh`
- `cd ytapp && npm install`
- `cd src-tauri && cargo check`
- `cd .. && npx ts-node src/cli.ts --help`


------
https://chatgpt.com/codex/tasks/task_e_684b6e362b38833199660100559ec714