### PR TITLE
Add cargo check troubleshooting

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -234,6 +234,12 @@ make verify
 ```
 The CI pipeline runs the same command using the devcontainer image.
 
+### Troubleshooting `cargo check`
+
+Errors about `gobject-2.0` or `gobject-sys` usually mean `PKG_CONFIG_PATH` is not
+set. Run `scripts/install_tauri_deps.sh` and then source `.env.tauri` (as noted
+in `AGENTS.md`) before re-running `cargo check`.
+
 To automatically process files placed in a folder set the **Watch Directory**
 and enable **Auto Upload** in the settings page or use the CLI `watch` command.
 


### PR DESCRIPTION
## Summary
- explain why `gobject-2.0` errors happen
- show how to fix `cargo check` problems

## Testing
- `npm install` in `ytapp`
- `cargo check` in `ytapp/src-tauri`
- `npx ts-node src/cli.ts --help` in `ytapp`

------
https://chatgpt.com/codex/tasks/task_e_684b74276c948331acfbe9aeed686878