### PR TITLE
Add docs index and README links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,15 @@
+# Documentation Index
+
+This folder summarizes the key documents found in the repository.
+
+- **[readme.md](../readme.md)** – Implementation plan and quick start guide covering features, setup and CLI usage.
+- **[AGENTS.md](../AGENTS.md)** – Development conventions and required verification commands.
+- **[CONTRIBUTING.md](../CONTRIBUTING.md)** – Instructions for adding new languages and general contribution advice.
+- **[context.md](../context.md)** – Overview of the project structure and how the frontend and backend communicate.
+- **[design.md](../design.md)** – Minimalist design rules influenced by Dieter Rams and Jony Ive.
+- **[SELF_REFLECTION.md](../SELF_REFLECTION.md)** – Notes on how the Codex agent operates within this repository.
+- **[prompt.md](../prompt.md)** – Original prompt that sparked development of the application.
+- **[prompttracking.md](../prompttracking.md)** – History of major prompt updates.
+- **[pullrequest_merge_conflict.md](../pullrequest_merge_conflict.md)** – Guide for resolving PR merge conflicts.
+- **[design/wireframes/README.md](../design/wireframes/README.md)** – Placeholder for future wireframe images.
+

--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,7 @@
 10. [Design Guidelines](#design-guidelines)
 11. [Custom Fonts](#custom-fonts)
 12. [CLI Usage](#cli-usage)
+13. [Documentation](#documentation)
 
 
 ### Quick start
@@ -381,3 +382,14 @@ npx ts-node src/cli.ts generate input.wav --profile gaming
 
 
 
+
+### Documentation
+
+Additional references live in the `docs` folder:
+
+- [Documentation Index](docs/index.md)
+- [Contribution Guide](CONTRIBUTING.md)
+- [Development Instructions](AGENTS.md)
+- [Design Guide](design.md)
+- [Project Overview](context.md)
+- [Codex Self Reflection](SELF_REFLECTION.md)


### PR DESCRIPTION
## Summary
- list repository docs under `docs/index.md`
- link README to new docs section

## Testing
- `npm install` in `ytapp`
- `cargo check` in `ytapp/src-tauri`
- `npx ts-node src/cli.ts --help` in `ytapp`

------
https://chatgpt.com/codex/tasks/task_e_684b897bb3ec8331af0dc655bd9c3d11