### PR TITLE
Add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 YouTubeAutomation contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/readme.md
+++ b/readme.md
@@ -393,3 +393,5 @@ Additional references live in the `docs` folder:
 - [Design Guide](design.md)
 - [Project Overview](context.md)
 - [Codex Self Reflection](SELF_REFLECTION.md)
+
+Licensed under the MIT License.

--- a/ytapp/package.json
+++ b/ytapp/package.json
@@ -31,5 +31,6 @@
   },
   "husky": {
     "skipCI": true
-  }
+  },
+  "license": "MIT"
 }

--- a/ytapp/src-tauri/Cargo.toml
+++ b/ytapp/src-tauri/Cargo.toml
@@ -3,6 +3,7 @@ name = "ytapp"
 version = "0.1.0"
 edition = "2021"
 build = "build.rs"
+license = "MIT"
 
 [dependencies]
 tauri = { version = "=1.8.3", features = ["dialog"] }


### PR DESCRIPTION
## Summary
- add MIT license
- reference the license in readme
- specify the license in package.json and Cargo.toml

## Testing
- `npm install` in `ytapp`
- `cargo check` in `ytapp/src-tauri`
- `npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_684ba162ab1483319f004e38f52d3039