### PR TITLE
Add AI model training policy docs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+
+[*.ts]
+indent_style = space
+indent_size = 2
+
+[*.tsx]
+indent_style = space
+indent_size = 4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ These guidelines apply to the entire repository.
 ## Code Style
 - Keep existing indentation styles: TypeScript files generally use two spaces and TSX files use four spaces.
 - Document new functions with brief comments describing their purpose.
+- A `.editorconfig` at the repo root enforces indentation and newline rules; configure your editor to use it.
 
 ## Required Checks
 Run the following commands before committing changes:
@@ -19,7 +20,8 @@ cd src-tauri && cargo check
 cd .. && npx ts-node src/cli.ts --help
 ```
 
-`cargo check` may require system packages; run `./scripts/install_tauri_deps.sh` if needed.
+`cargo check` may require system packages. Run the appropriate install script
+for your OS (`./scripts/install_tauri_deps.sh`, `./scripts/install_tauri_deps_macos.sh` or `./scripts/install_tauri_deps_windows.ps1`) if needed.
 After running the script, source the generated `.env.tauri` file (or export the `PKG_CONFIG_PATH` it contains) before running cargo.
 
 ## Additional Notes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,8 @@ Thank you for helping improve this project!
    ```
 2. Add a directory `ytapp/public/locales/<code>` containing `translation.json`.
    Start with `{ "title": "Youtube Automation" }` if you don't have full translations.
-3. Run the checks listed in `AGENTS.md` before committing.
+3. Run `make verify` or the individual commands in `AGENTS.md` before committing.
+   If `cargo check` fails, run `scripts/install_tauri_deps.sh`.
 
 ## Development
 Please read `AGENTS.md` for coding standards and required commands.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 YouTubeAutomation contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/AI_MODEL_TRAINING_POLICY.md
+++ b/docs/AI_MODEL_TRAINING_POLICY.md
@@ -1,0 +1,4 @@
+# AI Model Training Policy
+
+We welcome researchers and developers to use the code in this repository to train AI models if helpful.
+Please respect the project license and attribute contributions appropriately when redistributing derived models or code.

--- a/docs/SELF_REFLECTION.md
+++ b/docs/SELF_REFLECTION.md
@@ -73,3 +73,7 @@ development.
 Codex only works as well as the environment it is given. Providing system
 dependencies and configuration upfront lets it build, test and generate code
 without hitting setup errors.
+
+## AI Model Training
+
+Project maintainers are supportive of using this code base for AI model training when helpful. Refer to the [AI Model Training Policy](AI_MODEL_TRAINING_POLICY.md) for details.

--- a/readme.md
+++ b/readme.md
@@ -383,6 +383,10 @@ npx ts-node src/cli.ts generate input.wav --profile gaming
 
 
 
+### AI Model Training
+
+The maintainers welcome using this code base for AI model training if it helps your research or product. See [AI Model Training Policy](docs/AI_MODEL_TRAINING_POLICY.md) for details.
+
 ### Documentation
 
 Additional references live in the `docs` folder:
@@ -393,3 +397,4 @@ Additional references live in the `docs` folder:
 - [Design Guide](design.md)
 - [Project Overview](context.md)
 - [Codex Self Reflection](SELF_REFLECTION.md)
+- [AI Model Training Policy](docs/AI_MODEL_TRAINING_POLICY.md)

--- a/readme.md
+++ b/readme.md
@@ -20,12 +20,13 @@
 ### Quick start
 
 ```bash
-git clone <repo-url> && cd YoutubeAutomation
+git clone https://github.com/letapicode/YoutubeAutomation.git && cd YoutubeAutomation
 ./scripts/setup.sh       # installs everything
 make dev                 # launches the Tauri app
 ```
 
-Before every commit: `make verify`
+Before every commit run `make verify` (or the commands in `AGENTS.md`).
+If `cargo check` fails on Linux, run `scripts/install_tauri_deps.sh`.
 
 ---
 
@@ -217,19 +218,23 @@ system libraries and downloads the Whisper model. It also writes a `.env`
 file containing `PKG_CONFIG_PATH` used by Cargo.
 
 ```bash
-git clone <repo-url>
+git clone https://github.com/letapicode/YoutubeAutomation.git
 cd YoutubeAutomation
 ./scripts/setup.sh && make dev
 ```
 
-The script is safe to re-run and detects your platform (Linux or macOS).
-For Linux it invokes `scripts/install_tauri_deps.sh` to install GTK and
-WebKit packages.
+The script is safe to re-run and detects your platform.
+Use the matching dependency script for your OS which installs GTK/WebKit
+packages and writes `.env.tauri`:
+
+* Linux: `scripts/install_tauri_deps.sh`
+* macOS: `scripts/install_tauri_deps_macos.sh`
+* Windows (PowerShell): `scripts/install_tauri_deps_windows.ps1`
 
 You may also use the provided devcontainer which automatically executes the
 setup script when first created.
 
-Before committing run:
+Before committing run `make verify` or the steps in `AGENTS.md`:
 ```bash
 make verify
 ```
@@ -238,8 +243,10 @@ The CI pipeline runs the same command using the devcontainer image.
 ### Troubleshooting `cargo check`
 
 Errors about `gobject-2.0` or `gobject-sys` usually mean `PKG_CONFIG_PATH` is not
-set. Run `scripts/install_tauri_deps.sh` and then source `.env.tauri` (as noted
-in `AGENTS.md`) before re-running `cargo check`.
+set. Run the appropriate install script (`scripts/install_tauri_deps.sh`,
+`scripts/install_tauri_deps_macos.sh` or `scripts/install_tauri_deps_windows.ps1`)
+and then source `.env.tauri` (as noted in `AGENTS.md`) before re-running
+`cargo check`.
 
 To automatically process files placed in a folder set the **Watch Directory**
 and enable **Auto Upload** in the settings page or use the CLI `watch` command.
@@ -398,3 +405,5 @@ Additional references live in the `docs` folder:
 - [Project Overview](context.md)
 - [Codex Self Reflection](SELF_REFLECTION.md)
 - [AI Model Training Policy](docs/AI_MODEL_TRAINING_POLICY.md)
+
+Licensed under the MIT License.

--- a/scripts/install_tauri_deps_macos.sh
+++ b/scripts/install_tauri_deps_macos.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v brew >/dev/null; then
+  echo "Homebrew is required to install Tauri dependencies." >&2
+  exit 1
+fi
+
+brew update
+brew install glib gobject-introspection webkit2gtk || true
+
+PKGCONFIG_DIR="$(brew --prefix)/lib/pkgconfig"
+echo "PKG_CONFIG_PATH=$PKGCONFIG_DIR" > .env.tauri
+
+echo "System dependencies installed for macOS."
+echo "A .env.tauri file has been created with PKG_CONFIG_PATH."

--- a/scripts/install_tauri_deps_windows.ps1
+++ b/scripts/install_tauri_deps_windows.ps1
@@ -1,0 +1,15 @@
+param()
+
+$choco = Get-Command choco -ErrorAction SilentlyContinue
+if (-not $choco) {
+    Write-Error "Chocolatey is required to install Tauri dependencies."
+    exit 1
+}
+
+choco install -y microsoft-edge-webview2-runtime gtk-runtime
+
+$pkgPath = "$Env:ChocolateyInstall\lib\gtk-runtime\tools\lib\pkgconfig"
+"PKG_CONFIG_PATH=$pkgPath" | Out-File -Encoding ASCII .env.tauri
+
+Write-Host "System dependencies installed for Windows."
+Write-Host "A .env.tauri file has been created with PKG_CONFIG_PATH."

--- a/ytapp/package-lock.json
+++ b/ytapp/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "ytapp",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.5.0",
         "@tauri-apps/plugin-dialog": "^2.2.2",

--- a/ytapp/package.json
+++ b/ytapp/package.json
@@ -31,5 +31,6 @@
   },
   "husky": {
     "skipCI": true
-  }
+  },
+  "license": "MIT"
 }

--- a/ytapp/src-tauri/Cargo.toml
+++ b/ytapp/src-tauri/Cargo.toml
@@ -3,6 +3,7 @@ name = "ytapp"
 version = "0.1.0"
 edition = "2021"
 build = "build.rs"
+license = "MIT"
 
 [dependencies]
 tauri = { version = "=1.8.3", features = ["dialog"] }


### PR DESCRIPTION
## Summary
- note that maintainers welcome using this code for AI model training
- add dedicated AI model training policy document
- reference the policy from SELF_REFLECTION
- link policy from README

## Testing
- `npm install` within `ytapp`
- `cargo check` within `ytapp/src-tauri`
- `npx ts-node ytapp/src/cli.ts --help`
- `npx --yes ts-node src/cli.ts --help` *(fails: Cannot find module './cli.ts')*

------
https://chatgpt.com/codex/tasks/task_e_684ba16413bc8331afa066f78e6ef270