### PR TITLE
Add cross-platform dependency scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,8 @@ cd src-tauri && cargo check
 cd .. && npx ts-node src/cli.ts --help
 ```
 
-`cargo check` may require system packages; run `./scripts/install_tauri_deps.sh` if needed.
+`cargo check` may require system packages. Run the appropriate install script
+for your OS (`./scripts/install_tauri_deps.sh`, `./scripts/install_tauri_deps_macos.sh` or `./scripts/install_tauri_deps_windows.ps1`) if needed.
 After running the script, source the generated `.env.tauri` file (or export the `PKG_CONFIG_PATH` it contains) before running cargo.
 
 ## Additional Notes

--- a/readme.md
+++ b/readme.md
@@ -222,9 +222,13 @@ cd YoutubeAutomation
 ./scripts/setup.sh && make dev
 ```
 
-The script is safe to re-run and detects your platform (Linux or macOS).
-For Linux it invokes `scripts/install_tauri_deps.sh` to install GTK and
-WebKit packages.
+The script is safe to re-run and detects your platform.
+Use the matching dependency script for your OS which installs GTK/WebKit
+packages and writes `.env.tauri`:
+
+* Linux: `scripts/install_tauri_deps.sh`
+* macOS: `scripts/install_tauri_deps_macos.sh`
+* Windows (PowerShell): `scripts/install_tauri_deps_windows.ps1`
 
 You may also use the provided devcontainer which automatically executes the
 setup script when first created.
@@ -238,8 +242,10 @@ The CI pipeline runs the same command using the devcontainer image.
 ### Troubleshooting `cargo check`
 
 Errors about `gobject-2.0` or `gobject-sys` usually mean `PKG_CONFIG_PATH` is not
-set. Run `scripts/install_tauri_deps.sh` and then source `.env.tauri` (as noted
-in `AGENTS.md`) before re-running `cargo check`.
+set. Run the appropriate install script (`scripts/install_tauri_deps.sh`,
+`scripts/install_tauri_deps_macos.sh` or `scripts/install_tauri_deps_windows.ps1`)
+and then source `.env.tauri` (as noted in `AGENTS.md`) before re-running
+`cargo check`.
 
 To automatically process files placed in a folder set the **Watch Directory**
 and enable **Auto Upload** in the settings page or use the CLI `watch` command.

--- a/scripts/install_tauri_deps_macos.sh
+++ b/scripts/install_tauri_deps_macos.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v brew >/dev/null; then
+  echo "Homebrew is required to install Tauri dependencies." >&2
+  exit 1
+fi
+
+brew update
+brew install glib gobject-introspection webkit2gtk || true
+
+PKGCONFIG_DIR="$(brew --prefix)/lib/pkgconfig"
+echo "PKG_CONFIG_PATH=$PKGCONFIG_DIR" > .env.tauri
+
+echo "System dependencies installed for macOS."
+echo "A .env.tauri file has been created with PKG_CONFIG_PATH."

--- a/scripts/install_tauri_deps_windows.ps1
+++ b/scripts/install_tauri_deps_windows.ps1
@@ -1,0 +1,15 @@
+param()
+
+$choco = Get-Command choco -ErrorAction SilentlyContinue
+if (-not $choco) {
+    Write-Error "Chocolatey is required to install Tauri dependencies."
+    exit 1
+}
+
+choco install -y microsoft-edge-webview2-runtime gtk-runtime
+
+$pkgPath = "$Env:ChocolateyInstall\lib\gtk-runtime\tools\lib\pkgconfig"
+"PKG_CONFIG_PATH=$pkgPath" | Out-File -Encoding ASCII .env.tauri
+
+Write-Host "System dependencies installed for Windows."
+Write-Host "A .env.tauri file has been created with PKG_CONFIG_PATH."


### PR DESCRIPTION
## Summary
- add install scripts for macOS and Windows
- document cross-platform setup instructions in README
- mention the new scripts in AGENTS.md so required checks can use them

## Testing
- `npm install`
- `cargo check`
- `npx ts-node src/cli.ts --help`


------
https://chatgpt.com/codex/tasks/task_e_684ba16575408331a67a2de336a290f2