### PR TITLE
Update repo URL and contributor instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,8 @@ Thank you for helping improve this project!
    ```
 2. Add a directory `ytapp/public/locales/<code>` containing `translation.json`.
    Start with `{ "title": "Youtube Automation" }` if you don't have full translations.
-3. Run the checks listed in `AGENTS.md` before committing.
+3. Run `make verify` or the individual commands in `AGENTS.md` before committing.
+   If `cargo check` fails, run `scripts/install_tauri_deps.sh`.
 
 ## Development
 Please read `AGENTS.md` for coding standards and required commands.

--- a/readme.md
+++ b/readme.md
@@ -20,12 +20,13 @@
 ### Quick start
 
 ```bash
-git clone <repo-url> && cd YoutubeAutomation
+git clone https://github.com/letapicode/YoutubeAutomation.git && cd YoutubeAutomation
 ./scripts/setup.sh       # installs everything
 make dev                 # launches the Tauri app
 ```
 
-Before every commit: `make verify`
+Before every commit run `make verify` (or the commands in `AGENTS.md`).
+If `cargo check` fails on Linux, run `scripts/install_tauri_deps.sh`.
 
 ---
 
@@ -217,7 +218,7 @@ system libraries and downloads the Whisper model. It also writes a `.env`
 file containing `PKG_CONFIG_PATH` used by Cargo.
 
 ```bash
-git clone <repo-url>
+git clone https://github.com/letapicode/YoutubeAutomation.git
 cd YoutubeAutomation
 ./scripts/setup.sh && make dev
 ```
@@ -229,7 +230,7 @@ WebKit packages.
 You may also use the provided devcontainer which automatically executes the
 setup script when first created.
 
-Before committing run:
+Before committing run `make verify` or the steps in `AGENTS.md`:
 ```bash
 make verify
 ```


### PR DESCRIPTION
## Summary
- use actual repo URL in the quick start and setup sections
- remind contributors to run `make verify` or the commands in `AGENTS.md`
- mention `scripts/install_tauri_deps.sh` for missing dependencies

## Testing
- `npm install` in `ytapp`
- `cargo check` *(fails: gobject-2.0 not found)*
- `npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_684ba16694ac83319c59813c9a77917c