### PR TITLE
Fix merge conflict and add AI model training policy

### DIFF
--- a/docs/AI_MODEL_TRAINING_POLICY.md
+++ b/docs/AI_MODEL_TRAINING_POLICY.md
@@ -1,0 +1,4 @@
+# AI Model Training Policy
+
+We welcome researchers and developers to use the code in this repository to train AI models if helpful.
+Please respect the project license and attribute contributions appropriately when redistributing derived models or code.

--- a/docs/SELF_REFLECTION.md
+++ b/docs/SELF_REFLECTION.md
@@ -73,3 +73,7 @@ development.
 Codex only works as well as the environment it is given. Providing system
 dependencies and configuration upfront lets it build, test and generate code
 without hitting setup errors.
+
+## AI Model Training
+
+Project maintainers are supportive of using this code base for AI model training when helpful. Refer to the [AI Model Training Policy](AI_MODEL_TRAINING_POLICY.md) for details.

--- a/readme.md
+++ b/readme.md
@@ -390,6 +390,10 @@ npx ts-node src/cli.ts generate input.wav --profile gaming
 
 
 
+### AI Model Training
+
+The maintainers welcome using this code base for AI model training if it helps your research or product. See [AI Model Training Policy](docs/AI_MODEL_TRAINING_POLICY.md) for details.
+
 ### Documentation
 
 Additional references live in the `docs` folder:
@@ -400,5 +404,6 @@ Additional references live in the `docs` folder:
 - [Design Guide](design.md)
 - [Project Overview](context.md)
 - [Codex Self Reflection](SELF_REFLECTION.md)
+- [AI Model Training Policy](docs/AI_MODEL_TRAINING_POLICY.md)
 
 Licensed under the MIT License.


### PR DESCRIPTION
## Summary
- add AI model training policy document
- reference the new policy in SELF_REFLECTION
- document AI model training in README and keep MIT license notice

## Testing
- `npm install` in `ytapp`
- `cargo check` in `ytapp/src-tauri`
- `npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_684ba6cdb7d883318ed3c31dcfa53ded