### PR TITLE
Start watch directory automatically

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -250,6 +250,7 @@ and then source `.env.tauri` (as noted in `AGENTS.md`) before re-running
 
 To automatically process files placed in a folder set the **Watch Directory**
 and enable **Auto Upload** in the settings page or use the CLI `watch` command.
+When the app starts it will immediately begin watching the configured folder.
 
 ### Contribution
 

--- a/ytapp/src/components/WatchStatus.tsx
+++ b/ytapp/src/components/WatchStatus.tsx
@@ -16,6 +16,7 @@ const WatchStatus: React.FC = () => {
         loadSettings().then(s => {
             setDir(s.watchDir || '');
             setAuto(!!s.autoUpload);
+            if (s.watchDir) setWatching(true);
         });
         const interval = setInterval(() => {
             listJobs().then(j => setQueueLen(j.length));

--- a/ytapp/src/main.tsx
+++ b/ytapp/src/main.tsx
@@ -5,11 +5,18 @@ import './style.css';
 import './theme.css';
 import './i18n';
 import { checkDependencies } from './features/dependencies';
+import { loadSettings } from './features/settings';
+import { watchDirectory } from './features/watch';
 
 const container = document.getElementById('root');
 if (container) {
     const root = createRoot(container);
-    checkDependencies().finally(() => {
+    (async () => {
+        const settings = await loadSettings();
+        if (settings.watchDir) {
+            await watchDirectory(settings.watchDir, { autoUpload: settings.autoUpload });
+        }
+        await checkDependencies();
         root.render(<App />);
-    });
+    })();
 }


### PR DESCRIPTION
## Summary
- load settings before rendering the Tauri app
- automatically start the watch directory if configured
- show active watch state on startup
- document automatic watch startup in README

## Testing
- `npm install`
- `source .env.tauri && cargo check`
- `npx -y ts-node ytapp/src/cli.ts --help`


------
https://chatgpt.com/codex/tasks/task_e_684bae36ff288331a71d5e0167ba1376