### PR TITLE
Improve a11y of buttons

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -187,6 +187,7 @@ If `cargo check` fails on Linux, run `scripts/install_tauri_deps.sh`.
 * Drag & drop support for file inputs
 * Theme toggle (light/dark)
 * Accessible labels and full keyboard navigation
+* Improved focus outlines and ARIA labels on modal and file picker buttons
 * Settings page with persistent defaults
 * Profiles page to save and load sets of options
  * Interface translations are handled via i18n files in `public/locales`.

--- a/ytapp/src/components/FilePicker.tsx
+++ b/ytapp/src/components/FilePicker.tsx
@@ -53,7 +53,12 @@ const FilePicker: React.FC<FilePickerProps> = ({ multiple, onSelect, label, filt
   }
 
   return (
-    <button onClick={handleClick}>{label || (multiple ? t('select_files') : t('select_file'))}</button>
+    <button
+      onClick={handleClick}
+      aria-label={label || (multiple ? t('select_files') : t('select_file'))}
+    >
+      {label || (multiple ? t('select_files') : t('select_file'))}
+    </button>
   );
 };
 

--- a/ytapp/src/components/Modal.tsx
+++ b/ytapp/src/components/Modal.tsx
@@ -12,7 +12,7 @@ const Modal: React.FC<ModalProps> = ({ open, onClose, children }) => {
     return (
         <div className="modal-overlay" onClick={onClose}>
             <div className="modal" onClick={e => e.stopPropagation()}>
-                <button className="close" onClick={onClose}>×</button>
+                <button className="close" onClick={onClose} aria-label="Close modal">×</button>
                 {children}
             </div>
         </div>

--- a/ytapp/src/style.css
+++ b/ytapp/src/style.css
@@ -81,3 +81,11 @@ button svg {
     align-items: stretch;
   }
 }
+
+button:focus,
+a:focus,
+input:focus,
+textarea:focus {
+  outline: 2px solid var(--text-color);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Summary
- add ARIA label to Modal close button
- label FilePicker button for screen readers
- show focus outlines for keyboard navigation
- document updated accessibility features

## Testing
- `npm install`
- `cargo check`
- `npx ts-node src/cli.ts --help`


------
https://chatgpt.com/codex/tasks/task_e_684bae3a6d3c8331a925069d83182a8e