### PR TITLE
Add desktop notifications for completed jobs

### DIFF
--- a/ytapp/src/App.tsx
+++ b/ytapp/src/App.tsx
@@ -25,6 +25,7 @@ import SettingsIcon from './components/SettingsIcon';
 import OnboardingModal from './components/OnboardingModal';
 import WatchStatus from './components/WatchStatus';
 import SubtitleEditor from './components/SubtitleEditor';
+import { notify } from './utils/notify';
 
 const App: React.FC = () => {
     const { t, i18n } = useTranslation();
@@ -125,6 +126,7 @@ const App: React.FC = () => {
         }, p => setProgress(Math.round(p)), () => setGenerating(false));
         setOutputs(o => [...o, out]);
         setGenerating(false);
+        notify('Generation complete', 'Video created successfully');
     };
 
     const buildParams = (): GenerateParams => ({
@@ -247,6 +249,7 @@ const App: React.FC = () => {
         await generateUpload(buildParams(), () => setGenerating(false));
         unlisten();
         setGenerating(false);
+        notify('Upload complete', 'Video uploaded successfully');
     };
 
     const cancelGenerate = async () => {

--- a/ytapp/src/components/BatchProcessor.tsx
+++ b/ytapp/src/components/BatchProcessor.tsx
@@ -10,6 +10,7 @@ import BatchOptionsForm from './BatchOptionsForm';
 import UploadIcon from './UploadIcon';
 import { open } from '@tauri-apps/plugin-dialog';
 import { parseCsv, CsvRow } from '../utils/csv';
+import { notify } from '../utils/notify';
 
 const BatchProcessor: React.FC = () => {
   const { t } = useTranslation();
@@ -71,6 +72,7 @@ const BatchProcessor: React.FC = () => {
       });
     }
     setRunning(false);
+    notify('Batch generate complete', `${files.length} video(s) processed`);
   };
 
   const cancelBatch = async () => {
@@ -97,6 +99,7 @@ const BatchProcessor: React.FC = () => {
       await generateBatchUpload({ files, ...options });
     }
     setUploading(false);
+    notify('Batch upload complete', `${files.length} video(s) uploaded`);
   };
 
   const cancelUpload = async () => {

--- a/ytapp/src/components/BatchUploader.tsx
+++ b/ytapp/src/components/BatchUploader.tsx
@@ -6,6 +6,7 @@ import { uploadVideo } from '../features/youtube';
 import UploadIcon from './UploadIcon';
 import { open } from '@tauri-apps/plugin-dialog';
 import { parseCsv, CsvRow } from '../utils/csv';
+import { notify } from '../utils/notify';
 
 const BatchUploader: React.FC = () => {
     const { t } = useTranslation();
@@ -68,6 +69,7 @@ const BatchUploader: React.FC = () => {
             );
         }
         setRunning(false);
+        notify('Batch upload complete', `${files.length} video(s) uploaded`);
     };
 
     return (

--- a/ytapp/src/utils/notify.ts
+++ b/ytapp/src/utils/notify.ts
@@ -1,0 +1,16 @@
+export async function notify(title: string, body: string) {
+  // Attempt to use the Web Notification API.
+  if ('Notification' in window) {
+    if (Notification.permission === 'granted') {
+      new Notification(title, { body });
+      return;
+    }
+    if (Notification.permission !== 'denied') {
+      const perm = await Notification.requestPermission();
+      if (perm === 'granted') {
+        new Notification(title, { body });
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- notify user when generation or upload jobs finish
- send notifications after single video operations
- alert after batch generate/upload tasks

## Testing
- `npm install`
- `cargo check`
- `npx ts-node src/cli.ts --help`


------
https://chatgpt.com/codex/tasks/task_e_684bb2755ae483319e9c5b2c42a9b850