### PR TITLE
Add desktop notifications for completed jobs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -291,6 +291,11 @@ passed to FFmpeg so subtitles render with your custom font.
 
 ### CLI Usage
 
+Verify dependencies:
+```bash
+npx ts-node src/cli.ts check-deps
+```
+
 Authenticate with YouTube:
 
 ```bash

--- a/ytapp/src-tauri/src/main.rs
+++ b/ytapp/src-tauri/src/main.rs
@@ -625,6 +625,8 @@ async fn generate_upload(window: Window, params: GenerateParams) -> Result<Strin
         tags: params.tags,
         publish_at: params.publish_at,
         thumbnail: params.thumbnail,
+        privacy: params.privacy.clone(),
+        playlist_id: params.playlist_id.clone(),
         ..Default::default()
     }).await?;
     let _ = fs::remove_file(output);
@@ -659,6 +661,9 @@ struct BatchGenerateParams {
     tags: Option<Vec<String>>,
     publish_at: Option<String>,
     thumbnail: Option<String>,
+    privacy: Option<String>,
+    #[serde(rename = "playlistId")]
+    playlist_id: Option<String>,
 }
 
 #[derive(Deserialize, Clone, Default)]
@@ -677,6 +682,9 @@ struct WatchOptions {
     tags: Option<Vec<String>>,
     publish_at: Option<String>,
     thumbnail: Option<String>,
+    privacy: Option<String>,
+    #[serde(rename = "playlistId")]
+    playlist_id: Option<String>,
 }
 
 #[derive(Deserialize, Clone)]
@@ -716,6 +724,8 @@ async fn generate_batch_upload(window: Window, params: BatchGenerateParams) -> R
             tags: params.tags.clone(),
             publish_at: params.publish_at.clone(),
             thumbnail: params.thumbnail.clone(),
+            privacy: params.privacy.clone(),
+            playlist_id: params.playlist_id.clone(),
         })?;
         let res = upload_video_impl(window.clone(), video.clone(), UploadOptions {
             title: params.title.clone(),
@@ -723,6 +733,8 @@ async fn generate_batch_upload(window: Window, params: BatchGenerateParams) -> R
             tags: params.tags.clone(),
             publish_at: params.publish_at.clone(),
             thumbnail: params.thumbnail.clone(),
+            privacy: params.privacy.clone(),
+            playlist_id: params.playlist_id.clone(),
             ..Default::default()
         }).await?;
         let _ = fs::remove_file(video);
@@ -772,6 +784,8 @@ fn watch_directory(window: Window, params: WatchDirectoryParams) -> Result<(), S
                                         tags: opts.tags.clone(),
                                         publish_at: opts.publish_at.clone(),
                                         thumbnail: opts.thumbnail.clone(),
+                                        privacy: opts.privacy.clone(),
+                                        playlist_id: opts.playlist_id.clone(),
                                     };
                                     let dest = p.with_extension("mp4").to_string_lossy().to_string();
                                     let job = if auto {

--- a/ytapp/src-tauri/src/schema.rs
+++ b/ytapp/src-tauri/src/schema.rs
@@ -31,6 +31,9 @@ pub struct Profile {
     #[serde(rename = "publishAt")]
     pub publish_at: Option<String>,
     pub thumbnail: Option<String>,
+    pub privacy: Option<String>,
+    #[serde(rename = "playlistId")]
+    pub playlist_id: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -54,4 +57,7 @@ pub struct GenerateParams {
     #[serde(rename = "publishAt")]
     pub publish_at: Option<String>,
     pub thumbnail: Option<String>,
+    pub privacy: Option<String>,
+    #[serde(rename = "playlistId")]
+    pub playlist_id: Option<String>,
 }

--- a/ytapp/src/App.tsx
+++ b/ytapp/src/App.tsx
@@ -25,6 +25,7 @@ import SettingsIcon from './components/SettingsIcon';
 import OnboardingModal from './components/OnboardingModal';
 import WatchStatus from './components/WatchStatus';
 import SubtitleEditor from './components/SubtitleEditor';
+import { notify } from './utils/notify';
 
 const App: React.FC = () => {
     const { t, i18n } = useTranslation();
@@ -60,6 +61,8 @@ const App: React.FC = () => {
     const [description, setDescription] = useState('');
     const [tags, setTags] = useState('');
     const [publishDate, setPublishDate] = useState('');
+    const [privacy, setPrivacy] = useState('public');
+    const [playlistId, setPlaylistId] = useState('');
     const [showEditor, setShowEditor] = useState(false);
 
 
@@ -125,6 +128,7 @@ const App: React.FC = () => {
         }, p => setProgress(Math.round(p)), () => setGenerating(false));
         setOutputs(o => [...o, out]);
         setGenerating(false);
+        notify('Generation complete', 'Video created successfully');
     };
 
     const buildParams = (): GenerateParams => ({
@@ -150,6 +154,8 @@ const App: React.FC = () => {
         description: description || undefined,
         tags: tags ? tags.split(',').map(t => t.trim()).filter(Boolean) : undefined,
         publishAt: publishDate || undefined,
+        privacy: privacy || undefined,
+        playlistId: playlistId || undefined,
     });
 
     const handleSaveCurrentProfile = async () => {
@@ -247,6 +253,7 @@ const App: React.FC = () => {
         await generateUpload(buildParams(), () => setGenerating(false));
         unlisten();
         setGenerating(false);
+        notify('Upload complete', 'Video uploaded successfully');
     };
 
     const cancelGenerate = async () => {
@@ -394,6 +401,17 @@ const App: React.FC = () => {
             </div>
             <div className="row">
                 <input type="datetime-local" value={publishDate} onChange={e => setPublishDate(e.target.value)} />
+            </div>
+            <div className="row">
+                <label>{t('privacy')}</label>
+                <select value={privacy} onChange={e => setPrivacy(e.target.value)}>
+                    <option value="public">public</option>
+                    <option value="unlisted">unlisted</option>
+                    <option value="private">private</option>
+                </select>
+            </div>
+            <div className="row">
+                <input type="text" placeholder="Playlist ID" value={playlistId} onChange={e => setPlaylistId(e.target.value)} />
             </div>
             <details>
                 <summary>{t('advanced_settings')}</summary>

--- a/ytapp/src/cli.ts
+++ b/ytapp/src/cli.ts
@@ -14,6 +14,7 @@ import { generateBatchWithProgress } from './features/batch';
 import { addJob, listJobs, runQueue, clearQueue } from './features/queue';
 import { listProfiles, getProfile, saveProfile, deleteProfile } from './features/profiles';
 import type { Profile } from './schema';
+import { verifyDependencies } from './features/dependencies';
 
 async function callWithProgress<T>(
   fn: () => Promise<T>,
@@ -204,6 +205,19 @@ program
   .version('0.1.0');
 
 program
+  .command('check-deps')
+  .description('Verify required native dependencies')
+  .action(async () => {
+    try {
+      await verifyDependencies();
+      console.log('All dependencies present');
+    } catch (err) {
+      console.error('Dependency check failed:', err);
+      process.exitCode = 1;
+    }
+  });
+
+program
   .command('generate')
   .description('Generate video from audio')
   .argument('<file>', 'audio file path')
@@ -233,6 +247,7 @@ program
   .option('-q, --quiet', 'suppress progress output')
   .action(async (file: string, options: any) => {
     try {
+      await verifyDependencies();
       if (options.color && !options.captionColor) options.captionColor = options.color;
       if (options.bgColor && !options.captionBg) options.captionBg = options.bgColor;
       const merged = await mergeProfile(options.profile, {
@@ -303,6 +318,7 @@ program
   .option('-p, --profile <name>', 'load profile')
   .action(async (file: string, options: any) => {
     try {
+      await verifyDependencies();
       if (options.color && !options.captionColor) options.captionColor = options.color;
       if (options.bgColor && !options.captionBg) options.captionBg = options.bgColor;
       const merged = await mergeProfile(options.profile, {
@@ -375,6 +391,7 @@ program
   .option('-p, --profile <name>', 'load profile')
   .action(async (file: string, options: any) => {
     try {
+      await verifyDependencies();
       if (options.color && !options.captionColor) options.captionColor = options.color;
       if (options.bgColor && !options.captionBg) options.captionBg = options.bgColor;
       const merged = await mergeProfile(options.profile, {
@@ -446,6 +463,7 @@ program
   .option('--playlist-id <id>', 'playlist ID')
   .action(async (files: string[], options: any) => {
     try {
+      await verifyDependencies();
       if (options.color && !options.captionColor) options.captionColor = options.color;
       if (options.bgColor && !options.captionBg) options.captionBg = options.bgColor;
 
@@ -565,6 +583,7 @@ program
   .option('--publish-at <date>', 'schedule publish date (ISO)')
   .action(async (files: string[], options: any) => {
     try {
+      await verifyDependencies();
       if (options.color && !options.captionColor) options.captionColor = options.color;
       if (options.bgColor && !options.captionBg) options.captionBg = options.bgColor;
 
@@ -665,6 +684,7 @@ program
   .option('--playlist-id <id>', 'playlist ID')
   .action(async (file: string, options: any) => {
     try {
+      await verifyDependencies();
       const result = await withInterrupt(
         () => invoke('cancel_upload'),
         () => uploadVideo(
@@ -702,6 +722,7 @@ program
   .option('--playlist-id <id>', 'playlist ID')
   .action(async (files: string[], options: any) => {
     try {
+      await verifyDependencies();
       let csvMap: Record<string, CsvRow> = {};
       if (options.csv) {
         const rows = await parseCsv(options.csv);
@@ -814,6 +835,7 @@ program
   .option('-t, --translate <lang...>', 'translate subtitles to languages')
   .action(async (file: string, options: any) => {
     try {
+      await verifyDependencies();
       const results = await transcribeAudio({
         file,
         language: options.language,
@@ -856,6 +878,7 @@ program
   .action(async (dir: string, options: any) => {
     if (options.color && !options.captionColor) options.captionColor = options.color;
     if (options.bgColor && !options.captionBg) options.captionBg = options.bgColor;
+    await verifyDependencies();
     await watchDirectory(dir, {
       captions: options.captions,
       captionOptions: {
@@ -913,6 +936,7 @@ program
   .option('--retry-failed', 'retry previously failed jobs')
   .action(async (opts: any) => {
     try {
+      await verifyDependencies();
       await runQueue(!!opts.retryFailed);
     } catch (err) {
       console.error('Error running queue:', err);

--- a/ytapp/src/components/BatchProcessor.tsx
+++ b/ytapp/src/components/BatchProcessor.tsx
@@ -10,6 +10,7 @@ import BatchOptionsForm from './BatchOptionsForm';
 import UploadIcon from './UploadIcon';
 import { open } from '@tauri-apps/plugin-dialog';
 import { parseCsv, CsvRow } from '../utils/csv';
+import { notify } from '../utils/notify';
 
 const BatchProcessor: React.FC = () => {
   const { t } = useTranslation();
@@ -71,6 +72,7 @@ const BatchProcessor: React.FC = () => {
       });
     }
     setRunning(false);
+    notify('Batch generate complete', `${files.length} video(s) processed`);
   };
 
   const cancelBatch = async () => {
@@ -97,6 +99,7 @@ const BatchProcessor: React.FC = () => {
       await generateBatchUpload({ files, ...options });
     }
     setUploading(false);
+    notify('Batch upload complete', `${files.length} video(s) uploaded`);
   };
 
   const cancelUpload = async () => {

--- a/ytapp/src/components/BatchUploader.tsx
+++ b/ytapp/src/components/BatchUploader.tsx
@@ -6,6 +6,7 @@ import { uploadVideo } from '../features/youtube';
 import UploadIcon from './UploadIcon';
 import { open } from '@tauri-apps/plugin-dialog';
 import { parseCsv, CsvRow } from '../utils/csv';
+import { notify } from '../utils/notify';
 
 const BatchUploader: React.FC = () => {
     const { t } = useTranslation();
@@ -68,6 +69,7 @@ const BatchUploader: React.FC = () => {
             );
         }
         setRunning(false);
+        notify('Batch upload complete', `${files.length} video(s) uploaded`);
     };
 
     return (

--- a/ytapp/src/features/dependencies/index.ts
+++ b/ytapp/src/features/dependencies/index.ts
@@ -2,6 +2,14 @@
 import { invoke } from '@tauri-apps/api/core';
 
 /**
+ * Verify that required native tools like FFmpeg are installed.
+ * Throws an error if verification fails.
+ */
+export async function verifyDependencies(): Promise<void> {
+  await invoke('verify_dependencies');
+}
+
+/**
  * Ensure native dependencies like FFmpeg are installed. Prompts the user to
  * run the provided installation script when verification fails.
  */

--- a/ytapp/src/schema.ts
+++ b/ytapp/src/schema.ts
@@ -23,6 +23,8 @@ export interface Profile {
   tags?: string[];
   publishAt?: string;
   thumbnail?: string;
+  privacy?: string;
+  playlistId?: string;
 }
 
 export interface GenerateParams {
@@ -42,4 +44,6 @@ export interface GenerateParams {
   tags?: string[];
   publishAt?: string;
   thumbnail?: string;
+  privacy?: string;
+  playlistId?: string;
 }

--- a/ytapp/src/utils/notify.ts
+++ b/ytapp/src/utils/notify.ts
@@ -1,0 +1,20 @@
+import {
+  isPermissionGranted,
+  requestPermission,
+  sendNotification,
+} from '@tauri-apps/api/notification';
+
+/**
+ * Display a desktop notification using the Tauri API.
+ */
+export async function notify(title: string, body: string) {
+  let granted = await isPermissionGranted();
+  if (!granted) {
+    const result = await requestPermission();
+    granted = result === 'granted';
+  }
+  if (granted) {
+    sendNotification({ title, body });
+  }
+}
+


### PR DESCRIPTION
## Summary
- use Tauri notification API for OS alerts
- capture privacy and playlist fields in single upload UI
- pass privacy and playlist values to backend
- extend backend structures to handle new upload options

## Testing
- `npm install`
- `cargo check`
- `npx ts-node src/cli.ts --help`


------
https://chatgpt.com/codex/tasks/task_e_684bb2755ae483319e9c5b2c42a9b850