### PR TITLE
Configure devcontainer build workflow

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,6 @@
 {
   "name": "ytapp-dev",
-  "build": {
-    "dockerfile": "Dockerfile",
-    "context": ".."
-  },
+  "image": "ghcr.io/<OWNER>/ytapp-dev:latest",
   "postCreateCommand": "./scripts/setup.sh && make verify",
   "updateContentCommand": "./scripts/setup.sh",
   "customizations": {

--- a/.github/workflows/build-devcontainer.yml
+++ b/.github/workflows/build-devcontainer.yml
@@ -1,0 +1,32 @@
+name: Build Devcontainer
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: .devcontainer/Dockerfile
+          tags: ghcr.io/${{ github.repository_owner }}/ytapp-dev:latest
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/readme.md
+++ b/readme.md
@@ -234,6 +234,7 @@ packages and writes `.env.tauri`:
 
 You may also use the provided devcontainer which automatically executes the
 setup script when first created.
+Codex and all contributors should open the repo using the prebuilt image `ghcr.io/<OWNER>/ytapp-dev:latest` for the fastest startup.
 
 Before committing run `make verify` or the steps in `AGENTS.md`:
 ```bash


### PR DESCRIPTION
## Summary
- add workflow to build/push devcontainer image to GHCR
- use the GHCR image in devcontainer.json
- mention prebuilt image in README for faster startup

## Testing
- `npm install` in `ytapp`
- `cargo check` in `ytapp/src-tauri`
- `npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_684c913554888331b981283a4d0b29fc