### PR TITLE
Update AGENTS with devcontainer info

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,12 @@
 
 These guidelines apply to the entire repository.
 
+## Devcontainer
+A pre-built development container image exists for this project. Codex should
+start from this image (or run `devcontainer open` if supported) before executing
+`make verify`. The container runs `scripts/setup.sh` automatically, so manual
+invocation of that script is unnecessary.
+
 ## Project Structure
 - The Tauri desktop application is under `ytapp`.
 - Rust sources live in `ytapp/src-tauri/src` and TypeScript/React sources in `ytapp/src`.


### PR DESCRIPTION
## Summary
- mention pre-built devcontainer image
- instruct Codex to open the container before running checks
- clarify that scripts/setup.sh runs automatically within the devcontainer

## Testing
- `npm install`
- `cargo check` *(fails: glib-2.0 not found)*
- `npx ts-node src/cli.ts --help`


------
https://chatgpt.com/codex/tasks/task_e_684c914959708331ba7f3c64a20533bc