### PR TITLE
Add Codex bootstrap Dockerfile

### DIFF
--- a/.codex/Dockerfile
+++ b/.codex/Dockerfile
@@ -1,0 +1,7 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-22.04
+WORKDIR /workspace
+COPY scripts/ ./scripts/
+RUN chmod +x ./scripts/bootstrap.sh && ./scripts/bootstrap.sh
+COPY ytapp/package.json ytapp/package-lock.json ./ytapp/
+RUN cd ytapp && npm install --ignore-scripts
+RUN cd ytapp/src-tauri && cargo fetch

--- a/.codex/config.yaml
+++ b/.codex/config.yaml
@@ -1,3 +1,5 @@
+image:
+  dockerfile: .codex/Dockerfile
 bootstrap: .codex/bootstrap.sh
 workflow:
   default:

--- a/readme.md
+++ b/readme.md
@@ -235,6 +235,8 @@ packages and writes `.env.tauri`:
 You may also use the provided devcontainer which automatically executes the
 setup script when first created.
 Codex and all contributors should open the repo using the prebuilt image `ghcr.io/<OWNER>/ytapp-dev:latest` for the fastest startup.
+The same setup steps are mirrored in `.codex/Dockerfile` which Codex uses as a
+bootstrap container.
 
 Before committing run `make verify` or the steps in `AGENTS.md`:
 ```bash


### PR DESCRIPTION
## Summary
- create `.codex/Dockerfile` mirroring the devcontainer
- point Codex config to build that Dockerfile
- mention the bootstrap container in setup docs

## Testing
- `npm install` in `ytapp`
- `cargo check` in `ytapp/src-tauri`
- `npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_684c942ae5608331bb2d880971e2795e