### PR TITLE
Add codex setup script

### DIFF
--- a/.codex/bootstrap.sh
+++ b/.codex/bootstrap.sh
@@ -1,20 +1,10 @@
 #!/usr/bin/env bash
 set -e
 
-# 1) Install GTK/WebKit/GLib headers
-./scripts/install_tauri_deps.sh
+./scripts/setup_codex.sh
 
-# 2) Export PKG_CONFIG_PATH for this shell
 source .env.tauri
 
-# 3) Optional Ubuntu 24 / Debian 13 WebKit rename fix
-ln -sf /usr/lib/x86_64-linux-gnu/pkgconfig/webkit2gtk-4.1.pc \
-      /usr/lib/x86_64-linux-gnu/pkgconfig/webkit2gtk-4.0.pc
-ln -sf /usr/lib/x86_64-linux-gnu/pkgconfig/javascriptcoregtk-4.1.pc \
-      /usr/lib/x86_64-linux-gnu/pkgconfig/javascriptcoregtk-4.0.pc
-
-# 4) Quick health check
-cd ytapp
-npm install --no-fund --no-audit
-cd src-tauri
+cd ytapp/src-tauri
 cargo check --locked --all-targets
+

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@
 
 ```bash
 git clone https://github.com/letapicode/YoutubeAutomation.git && cd YoutubeAutomation
-./scripts/setup.sh       # installs everything
+./scripts/setup_codex.sh       # installs everything
 make dev                 # launches the Tauri app
 ```
 
@@ -214,14 +214,14 @@ If `cargo check` fails on Linux, run `scripts/install_tauri_deps.sh`.
 
 ### Setup
 
-Clone the repository and run the setup script which installs toolchains,
+Clone the repository and run the setup script (`scripts/setup_codex.sh`) which installs toolchains,
 system libraries and downloads the Whisper model. It also writes a `.env`
 file containing `PKG_CONFIG_PATH` used by Cargo.
 
 ```bash
 git clone https://github.com/letapicode/YoutubeAutomation.git
 cd YoutubeAutomation
-./scripts/setup.sh && make dev
+./scripts/setup_codex.sh && make dev
 ```
 
 The script is safe to re-run and detects your platform.
@@ -232,8 +232,7 @@ packages and writes `.env.tauri`:
 * macOS: `scripts/install_tauri_deps_macos.sh`
 * Windows (PowerShell): `scripts/install_tauri_deps_windows.ps1`
 
-You may also use the provided devcontainer which automatically executes the
-setup script when first created.
+You may also use the provided devcontainer which automatically executes the setup script (`scripts/setup_codex.sh`) when first created.
 Codex and all contributors should open the repo using the prebuilt image `ghcr.io/<OWNER>/ytapp-dev:latest` for the fastest startup.
 
 Before committing run `make verify` or the steps in `AGENTS.md`:

--- a/scripts/setup_codex.sh
+++ b/scripts/setup_codex.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+"$ROOT_DIR/scripts/bootstrap.sh"
+
+cd "$ROOT_DIR/ytapp"
+npm install
+cd src-tauri
+cargo fetch


### PR DESCRIPTION
## Summary
- add `scripts/setup_codex.sh` that installs toolchains, Whisper, npm packages and Cargo deps
- call this script in `.codex/bootstrap.sh`
- document `scripts/setup_codex.sh` as the main setup method in the README

## Testing
- `cd ytapp && npm install`
- `cd src-tauri && cargo check`
- `cd .. && npx -y ts-node ytapp/src/cli.ts --help`


------
https://chatgpt.com/codex/tasks/task_e_684c9434eddc8331bc5807263d649393