### PR TITLE
Document Codex container config

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,4 +12,5 @@ This folder summarizes the key documents found in the repository.
 - **[prompttracking.md](../prompttracking.md)** – History of major prompt updates.
 - **[pullrequest_merge_conflict.md](../pullrequest_merge_conflict.md)** – Guide for resolving PR merge conflicts.
 - **[design/wireframes/README.md](../design/wireframes/README.md)** – Placeholder for future wireframe images.
+- **Codex container setup** – `.codex/config.yaml` defines test commands and `.codex/bootstrap.sh` installs dependencies. Customize `.devcontainer/Dockerfile` and `scripts/setup.sh` to preload extra packages. Using a prebuilt image shortens container startup. For more details see [SELF_REFLECTION.md](../SELF_REFLECTION.md).
 

--- a/readme.md
+++ b/readme.md
@@ -242,6 +242,11 @@ make verify
 ```
 The CI pipeline runs the same command using the devcontainer image.
 
+
+### Codex Container
+
+`.codex/config.yaml` lists the verification steps Codex runs and points to `.codex/bootstrap.sh` for initial setup. Customize `.devcontainer/Dockerfile` and `scripts/setup.sh` to install additional packages or adjust the environment. Opening the repository with the prebuilt image speeds up container creation. See [docs/SELF_REFLECTION.md](docs/SELF_REFLECTION.md) for more details on Codex operations.
+
 ### Troubleshooting `cargo check`
 
 Errors about `gobject-2.0` or `gobject-sys` usually mean `PKG_CONFIG_PATH` is not


### PR DESCRIPTION
## Summary
- document Codex container setup in docs index
- add a "Codex Container" section in the readme

## Testing
- `npm install` in `ytapp`
- `cargo check` in `ytapp/src-tauri`
- `npx -y ts-node src/cli.ts --help` in `ytapp`

------
https://chatgpt.com/codex/tasks/task_e_684c9435dd5883319f6a7fe023f4e1c8