### PR TITLE
Resolve merge conflict and refine documentation

### DIFF
--- a/.codex/Dockerfile
+++ b/.codex/Dockerfile
@@ -1,7 +1,0 @@
-FROM mcr.microsoft.com/devcontainers/base:ubuntu-22.04
-WORKDIR /workspace
-COPY scripts/ ./scripts/
-RUN chmod +x ./scripts/bootstrap.sh && ./scripts/bootstrap.sh
-COPY ytapp/package.json ytapp/package-lock.json ./ytapp/
-RUN cd ytapp && npm install --ignore-scripts
-RUN cd ytapp/src-tauri && cargo fetch

--- a/.codex/bootstrap.sh
+++ b/.codex/bootstrap.sh
@@ -1,24 +1,15 @@
 #!/usr/bin/env bash
 set -e
 
-# 1) Install GTK/WebKit/GLib headers
-./scripts/install_tauri_deps.sh
+./scripts/setup_codex.sh
 
-# 2) Export PKG_CONFIG_PATH for this shell
 source .env.tauri
 
-# 3) Optional Ubuntu 24 / Debian 13 WebKit rename fix
+# Optional Ubuntu 24 / Debian 13 WebKit rename fix
 ln -sf /usr/lib/x86_64-linux-gnu/pkgconfig/webkit2gtk-4.1.pc \
       /usr/lib/x86_64-linux-gnu/pkgconfig/webkit2gtk-4.0.pc
 ln -sf /usr/lib/x86_64-linux-gnu/pkgconfig/javascriptcoregtk-4.1.pc \
       /usr/lib/x86_64-linux-gnu/pkgconfig/javascriptcoregtk-4.0.pc
 
-# 4) Quick health check
-cd ytapp
-if [ ! -d node_modules ]; then
-  npm install --no-fund --no-audit
-fi
-cd src-tauri
-if [ ! -d target ]; then
-  cargo check --locked --all-targets
-fi
+cd ytapp/src-tauri
+cargo check --locked --all-targets

--- a/.codex/config.yaml
+++ b/.codex/config.yaml
@@ -1,5 +1,3 @@
-image:
-  dockerfile: .codex/Dockerfile
 bootstrap: .codex/bootstrap.sh
 workflow:
   default:

--- a/docs/SELF_REFLECTION.md
+++ b/docs/SELF_REFLECTION.md
@@ -31,6 +31,8 @@ This document summarizes how the Codex agent operates and how it should be guide
 - The agent runs in an isolated container without internet access unless explicitly enabled by the user.
 - If required dependencies are missing, commands or tests may fail. The agent should report such issues and may include a disclaimer about environment limitations in the PR.
 
+Codex currently spins up a fresh container for every task, reinstalling all dependencies each time. This overhead slows the feedback loop. Adding a preconfigured setup script or Dockerfile would let the agent reuse cached packages and speed up initialization. Exploring ways to cache dependencies or use a prebuilt image is a future goal.
+
 ## 🛠️ The Codex Journey: What Really Happens Behind the Scenes
 
 The following walkthrough illustrates how Codex sets up its environment and why

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,5 +12,4 @@ This folder summarizes the key documents found in the repository.
 - **[prompttracking.md](../prompttracking.md)** – History of major prompt updates.
 - **[pullrequest_merge_conflict.md](../pullrequest_merge_conflict.md)** – Guide for resolving PR merge conflicts.
 - **[design/wireframes/README.md](../design/wireframes/README.md)** – Placeholder for future wireframe images.
-- **Codex container setup** – `.codex/config.yaml` defines test commands and `.codex/bootstrap.sh` installs dependencies. Customize `.devcontainer/Dockerfile` and `scripts/setup.sh` to preload extra packages. Using a prebuilt image shortens container startup. For more details see [SELF_REFLECTION.md](../SELF_REFLECTION.md).
 

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@
 
 ```bash
 git clone https://github.com/letapicode/YoutubeAutomation.git && cd YoutubeAutomation
-./scripts/setup.sh       # installs everything
+./scripts/setup_codex.sh       # installs everything
 make dev                 # launches the Tauri app
 ```
 
@@ -214,14 +214,14 @@ If `cargo check` fails on Linux, run `scripts/install_tauri_deps.sh`.
 
 ### Setup
 
-Clone the repository and run the setup script which installs toolchains,
+Clone the repository and run the setup script (`scripts/setup_codex.sh`) which installs toolchains,
 system libraries and downloads the Whisper model. It also writes a `.env`
 file containing `PKG_CONFIG_PATH` used by Cargo.
 
 ```bash
 git clone https://github.com/letapicode/YoutubeAutomation.git
 cd YoutubeAutomation
-./scripts/setup.sh && make dev
+./scripts/setup_codex.sh && make dev
 ```
 
 The script is safe to re-run and detects your platform.
@@ -232,8 +232,7 @@ packages and writes `.env.tauri`:
 * macOS: `scripts/install_tauri_deps_macos.sh`
 * Windows (PowerShell): `scripts/install_tauri_deps_windows.ps1`
 
-You may also use the provided devcontainer which automatically executes the
-setup script when first created.
+You may also use the provided devcontainer which automatically executes the setup script (`scripts/setup_codex.sh`) when first created.
 Codex and all contributors should open the repo using the prebuilt image `ghcr.io/<OWNER>/ytapp-dev:latest` for the fastest startup.
 The same setup steps are mirrored in `.codex/Dockerfile` which Codex uses as a
 bootstrap container.

--- a/scripts/setup_codex.sh
+++ b/scripts/setup_codex.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+"$ROOT_DIR/scripts/bootstrap.sh"
+
+cd "$ROOT_DIR/ytapp"
+npm install
+cd src-tauri
+cargo fetch


### PR DESCRIPTION
## Summary
- merge `codex/create-setup_codex.sh-for-environment-setup` with `main`
- call `scripts/setup_codex.sh` from `.codex/bootstrap.sh`
- remove obsolete Codex Dockerfile configuration
- drop container setup bullet from `docs/index.md`
- note container startup overhead in `docs/SELF_REFLECTION.md`

## Testing
- `npm install`
- `cargo check`
- `npx ts-node src/cli.ts --help`


------
https://chatgpt.com/codex/tasks/task_e_684c99235ba4833190f3ac0ac7bbfce9