### PR TITLE
Add codex container config

### DIFF
--- a/.codex/Dockerfile
+++ b/.codex/Dockerfile
@@ -1,0 +1,7 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-22.04
+WORKDIR /workspace
+COPY scripts/ ./scripts/
+RUN chmod +x ./scripts/bootstrap.sh && ./scripts/bootstrap.sh
+COPY ytapp/package.json ytapp/package-lock.json ./ytapp/
+RUN cd ytapp && npm install --ignore-scripts
+RUN cd ytapp/src-tauri && cargo fetch

--- a/.codex/config.yaml
+++ b/.codex/config.yaml
@@ -1,4 +1,5 @@
 bootstrap: .codex/bootstrap.sh
+image: ghcr.io/<OWNER>/ytapp-dev:latest
 workflow:
   default:
     - description: "Run unit & CLI tests"


### PR DESCRIPTION
## Summary
- add Dockerfile for Codex container
- reference prebuilt devcontainer image in Codex config

## Testing
- `npm install`
- `cargo check`
- `npx ts-node src/cli.ts --help`


------
https://chatgpt.com/codex/tasks/task_e_684ca543a6d483318258cf330bf7a9f9