### PR TITLE
Streamline setup scripts

### DIFF
--- a/.codex/Dockerfile
+++ b/.codex/Dockerfile
@@ -1,7 +1,4 @@
 FROM mcr.microsoft.com/devcontainers/base:ubuntu-22.04
 WORKDIR /workspace
-COPY scripts/ ./scripts/
-RUN chmod +x ./scripts/bootstrap.sh && ./scripts/bootstrap.sh
-COPY ytapp/package.json ytapp/package-lock.json ./ytapp/
-RUN cd ytapp && npm install --ignore-scripts
-RUN cd ytapp/src-tauri && cargo fetch
+COPY . .
+RUN chmod +x ./scripts/setup.sh && ./scripts/setup.sh

--- a/.codex/bootstrap.sh
+++ b/.codex/bootstrap.sh
@@ -1,19 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-./scripts/setup_codex.sh
+./scripts/setup.sh
 
 source .env.tauri
-
-# Optional Ubuntu 24 / Debian 13 WebKit rename fix
-ln -sf /usr/lib/x86_64-linux-gnu/pkgconfig/webkit2gtk-4.1.pc \
-      /usr/lib/x86_64-linux-gnu/pkgconfig/webkit2gtk-4.0.pc
-ln -sf /usr/lib/x86_64-linux-gnu/pkgconfig/javascriptcoregtk-4.1.pc \
-      /usr/lib/x86_64-linux-gnu/pkgconfig/javascriptcoregtk-4.0.pc
-
-if [ -d ytapp/src-tauri/target ]; then
-    echo "Rust target directory exists; skipping cargo check"
-else
-    cd ytapp/src-tauri
-    cargo check --locked --all-targets
-fi

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,4 @@
 FROM mcr.microsoft.com/devcontainers/base:ubuntu-22.04
 WORKDIR /workspace
-COPY scripts/ ./scripts/
-RUN chmod +x ./scripts/bootstrap.sh && ./scripts/bootstrap.sh
-COPY ytapp/package.json ytapp/package-lock.json ./ytapp/
-RUN cd ytapp && npm install --ignore-scripts
-RUN cd ytapp/src-tauri && cargo fetch
+COPY . .
+RUN chmod +x ./scripts/setup.sh && ./scripts/setup.sh

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -2,6 +2,9 @@
 set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+# Perform OS level setup and download the Whisper model
+"$ROOT_DIR/scripts/bootstrap.sh"
+
 # Install language toolchains using asdf if available
 if ! command -v asdf >/dev/null; then
   git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.14.0
@@ -36,10 +39,13 @@ if [ -f "$ROOT_DIR/.env.tauri" ]; then
   source "$ROOT_DIR/.env.tauri"
 fi
 
-# Run npm ci and setup Husky
+# Run npm install and setup Husky
 cd "$ROOT_DIR/ytapp"
-npm ci
-npm install --package-lock-only --yes
+if [ -d node_modules ]; then
+  echo "node_modules already present; skipping npm install"
+else
+  npm install
+fi
 if [ "${CI:-}" = "1" ]; then
   HUSKY=0 npx husky install
 else
@@ -47,13 +53,19 @@ else
 fi
 cd "$ROOT_DIR"
 
-# Cargo check if PKG_CONFIG_PATH is set
+# Cargo fetch and check if PKG_CONFIG_PATH is set
 if [ -n "${PKG_CONFIG_PATH:-}" ]; then
-  (cd ytapp/src-tauri && cargo check --quiet)
+  cd ytapp/src-tauri
+  if [ -d target ]; then
+    echo "Rust target directory exists; skipping cargo fetch"
+  else
+    cargo fetch
+  fi
+  cargo check --quiet
+  cd "$ROOT_DIR"
 else
   echo "PKG_CONFIG_PATH not set. Run scripts/install_tauri_deps.sh" >&2
   exit 1
 fi
 
-# Warm Whisper model
-"$ROOT_DIR/scripts/bootstrap.sh" >/dev/null
+# Setup complete

--- a/scripts/setup_codex.sh
+++ b/scripts/setup_codex.sh
@@ -2,18 +2,4 @@
 set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-"$ROOT_DIR/scripts/bootstrap.sh"
-
-cd "$ROOT_DIR/ytapp"
-if [ -d node_modules ]; then
-    echo "node_modules already present; skipping npm install"
-else
-    npm install
-fi
-
-cd src-tauri
-if [ -d target ]; then
-    echo "Rust target directory exists; skipping cargo fetch"
-else
-    cargo fetch
-fi
+"$ROOT_DIR/scripts/setup.sh"


### PR DESCRIPTION
## Summary
- centralize setup steps in `scripts/setup.sh`
- make `setup_codex.sh` call `setup.sh`
- simplify Codex bootstrap
- update devcontainer and Codex Dockerfiles

## Testing
- `npm install`
- `cargo check`
- `npx ts-node src/cli.ts --help`


------
https://chatgpt.com/codex/tasks/task_e_684cac0e45308331a1082345b60ee0b1