### PR TITLE
Update setup docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,10 @@ These guidelines apply to the entire repository.
 ## Devcontainer
 A pre-built development container image exists for this project: `ghcr.io/<OWNER>/ytapp-dev:latest`. Codex should
 start from this image (or run `devcontainer open` if supported) before executing
-`make verify`. The container runs `scripts/setup.sh` automatically via `.codex/bootstrap.sh`, so manual
-invocation of that script is unnecessary.
+`make verify`. Environment initialization is handled by `scripts/setup_codex.sh`
+(invoked automatically via `.codex/bootstrap.sh`). This script installs Tauri
+dependencies and writes `.env.tauri`. Source that file or restart your shell so
+its variables are available before running any checks.
 
 ## Project Structure
 - The Tauri desktop application is under `ytapp`.
@@ -28,7 +30,8 @@ cd .. && npx ts-node src/cli.ts --help
 
 `cargo check` may require system packages. Run the appropriate install script
 for your OS (`./scripts/install_tauri_deps.sh`, `./scripts/install_tauri_deps_macos.sh` or `./scripts/install_tauri_deps_windows.ps1`) if needed.
-After running the script, source the generated `.env.tauri` file (or export the `PKG_CONFIG_PATH` it contains) before running cargo.
+Be sure `.env.tauri` from `scripts/setup_codex.sh` is sourced (or export the
+`PKG_CONFIG_PATH` it contains) before running cargo.
 
 ## Additional Notes
 - Do not commit `.env.tauri` or build artifacts.

--- a/readme.md
+++ b/readme.md
@@ -215,9 +215,15 @@ If `cargo check` fails on Linux, run `scripts/install_tauri_deps.sh`.
 
 ### Setup
 
-Clone the repository and run the setup script (`scripts/setup_codex.sh`) which installs toolchains,
-system libraries and downloads the Whisper model. It also writes a `.env`
-file containing `PKG_CONFIG_PATH` used by Cargo.
+Clone the repository and run the setup script after entering the project
+directory. Use `./scripts/setup_codex.sh` locally or `.codex/bootstrap.sh`
+when starting the devcontainer. This script installs toolchains, downloads
+the Whisper model and calls `scripts/install_tauri_deps.sh` to install the
+required GTK/WebKit packages. It also writes `.env.tauri` which defines
+`PKG_CONFIG_PATH` for Cargo.
+
+After the script finishes **source `.env.tauri` or restart your shell** so
+the variables are available before running any Cargo commands.
 
 ```bash
 git clone https://github.com/letapicode/YoutubeAutomation.git


### PR DESCRIPTION
## Summary
- clarify setup process in README
- document environment initialization in AGENTS guidelines

## Testing
- `./scripts/setup_codex.sh`
- `cd ytapp && npm install`
- `cd src-tauri && cargo check`
- `cd .. && npx ts-node src/cli.ts --help`


------
https://chatgpt.com/codex/tasks/task_e_684cc2dc8b388331bcc58bc088bacd0e