### PR TITLE
Update bootstrap and setup scripts

### DIFF
--- a/.codex/bootstrap.sh
+++ b/.codex/bootstrap.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-./scripts/setup.sh
+./scripts/setup_codex.sh
 
 source .env.tauri

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@
 
 ```bash
 git clone https://github.com/letapicode/YoutubeAutomation.git && cd YoutubeAutomation
-./scripts/setup_codex.sh       # installs everything
+./scripts/setup_codex.sh       # installs everything (auto-run in Codex/devcontainer)
 make dev                 # launches the Tauri app
 ```
 

--- a/scripts/setup_codex.sh
+++ b/scripts/setup_codex.sh
@@ -3,3 +3,11 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 "$ROOT_DIR/scripts/setup.sh"
+
+if [[ "$(uname -s)" == "Linux" ]]; then
+  "$ROOT_DIR/scripts/install_tauri_deps.sh"
+fi
+
+if [ -f "$ROOT_DIR/.env.tauri" ]; then
+  source "$ROOT_DIR/.env.tauri"
+fi


### PR DESCRIPTION
## Summary
- call `scripts/setup_codex.sh` from `.codex/bootstrap.sh`
- extend `scripts/setup_codex.sh` to install tauri deps on Linux and source `.env.tauri`
- document Codex/devcontainer auto setup in the quick-start

## Testing
- `cd ytapp && npm install`
- `cd src-tauri && cargo check`
- `cd .. && npx ts-node src/cli.ts --help`
- `cd ytapp/src-tauri && cargo check`

------
https://chatgpt.com/codex/tasks/task_e_684ce1f9fc0083318df06e4ef26e907f