### PR TITLE
Implement updater config, language search, output path and profile import/export

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ This folder summarizes the key documents found in the repository.
 - **[CONTRIBUTING.md](../CONTRIBUTING.md)** – Instructions for adding new languages and general contribution advice.
 - **[context.md](../context.md)** – Overview of the project structure and how the frontend and backend communicate.
 - **[design.md](../design.md)** – Minimalist design rules influenced by Dieter Rams and Jony Ive.
-- **Auto-update** – The app checks for updates at startup using the Tauri updater plugin.
+- **Auto-update** – Updates are handled by the Tauri updater plugin which checks on startup.
 - **[SELF_REFLECTION.md](../SELF_REFLECTION.md)** – Notes on how the Codex agent operates within this repository.
 - **[prompt.md](../prompt.md)** – Original prompt that sparked development of the application.
 - **[prompttracking.md](../prompttracking.md)** – History of major prompt updates.

--- a/readme.md
+++ b/readme.md
@@ -189,6 +189,7 @@ If `cargo check` fails on Linux, run `scripts/install_tauri_deps.sh`.
 * Accessible labels and full keyboard navigation
 * Improved focus outlines and ARIA labels on modal and file picker buttons
 * Thumbnail selector in the GUI
+* Output path picker for generated videos
 * Settings page with persistent defaults
 * Profiles page to save and load sets of options
  * Interface translations are handled via i18n files in `public/locales`.
@@ -410,6 +411,8 @@ List or delete profiles:
 npx ts-node src/cli.ts profile-list
 npx ts-node src/cli.ts profile-delete gaming
 ```
+
+Profiles can also be imported or exported from the Profiles page in the GUI using JSON files.
 
 Use a profile with other commands using `--profile <name>`:
 

--- a/ytapp/src-tauri/Cargo.toml
+++ b/ytapp/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@ build = "build.rs"
 license = "MIT"
 
 [dependencies]
-tauri = { version = "=1.8.3", features = ["dialog"] }
+tauri = { version = "=1.8.3", features = ["dialog", "updater"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 whisper_cli = "0.1.5"

--- a/ytapp/src-tauri/tauri.conf.json
+++ b/ytapp/src-tauri/tauri.conf.json
@@ -7,6 +7,11 @@
     "bundle": {
       "identifier": "com.example.ytapp",
       "icon": ["icons/icon.png"]
+    },
+    "updater": {
+      "active": true,
+      "endpoints": [],
+      "pubkey": ""
     }
   }
 }

--- a/ytapp/src/App.tsx
+++ b/ytapp/src/App.tsx
@@ -14,6 +14,7 @@ import BatchPage from './components/BatchPage';
 import SettingsPage from './components/SettingsPage';
 import ProfilesPage from './components/ProfilesPage';
 import FontSelector from './components/FontSelector';
+import LanguageSelector from './components/LanguageSelector';
 import SizeSlider from './components/SizeSlider';
 import { languages, Language } from './features/languages';
 import TranscribeButton from './components/TranscribeButton';
@@ -28,8 +29,8 @@ import WatchStatus from './components/WatchStatus';
 import SubtitleEditor from './components/SubtitleEditor';
 import { notify } from './utils/notify';
 import UpdateModal from './components/UpdateModal';
-import { check } from '@tauri-apps/plugin-updater';
-import { relaunch } from '@tauri-apps/plugin-process';
+import { check } from '@tauri-apps/api/updater';
+import { relaunch } from '@tauri-apps/api/process';
 
 const App: React.FC = () => {
     const { t, i18n } = useTranslation();
@@ -73,6 +74,7 @@ const App: React.FC = () => {
     const [playlistId, setPlaylistId] = useState('');
     const [thumbnail, setThumbnail] = useState('');
     const [showEditor, setShowEditor] = useState(false);
+    const [output, setOutput] = useState('');
 
 
 
@@ -89,6 +91,7 @@ const App: React.FC = () => {
             if (s.captionBg) setCaptionBg(s.captionBg);
             if (s.watermark) setWatermark(s.watermark);
             if (s.watermarkPosition) setWatermarkPos(s.watermarkPosition as any);
+            if (s.output) setOutput(s.output);
             if (s.showGuide !== false) setShowGuide(true);
             if (s.watchDir) {
                 watchDirectory(s.watchDir, { autoUpload: s.autoUpload });
@@ -127,6 +130,7 @@ const App: React.FC = () => {
         setProgress(0);
         const out = await generateVideo({
             file,
+            output: output || undefined,
             captions: captions || undefined,
             captionOptions: {
                 font: font || undefined,
@@ -152,6 +156,7 @@ const App: React.FC = () => {
 
     const buildParams = (): GenerateParams => ({
         file,
+        output: output || undefined,
         captions: captions || undefined,
         captionOptions: {
             font: font || undefined,
@@ -350,11 +355,7 @@ const App: React.FC = () => {
         <div className="app">
             <h1>{t('title')}</h1>
             <div className="row">
-                <select value={i18n.language} onChange={e => i18n.changeLanguage(e.target.value)}>
-                    {languages.map(lang => (
-                        <option key={lang.value} value={lang.value}>{lang.label}</option>
-                    ))}
-                </select>
+                <LanguageSelector value={i18n.language as Language} onChange={l => i18n.changeLanguage(l)} />
                 <button onClick={toggleTheme}>{t('toggle_theme')}</button>
             </div>
             <div className="row">
@@ -363,6 +364,13 @@ const App: React.FC = () => {
                     else if (Array.isArray(p) && p.length) setFile(p[0]);
                 }} />
                 {file && <span>{file}</span>}
+            </div>
+            <div className="row">
+                <FilePicker label="Output" onSelect={(p) => {
+                    if (typeof p === 'string') setOutput(p);
+                    else if (Array.isArray(p) && p.length) setOutput(p[0]);
+                }} filters={[{ name: 'Video', extensions: ['mp4'] }]} />
+                {output && <span>{output}</span>}
             </div>
             <div className="row">
                 <FilePicker
@@ -526,11 +534,7 @@ const App: React.FC = () => {
             </div>
             </details>
             <div className="row">
-                <select value={language} onChange={(e) => setLanguage(e.target.value as Language)}>
-                    {languages.map(opt => (
-                        <option key={opt.value} value={opt.value}>{opt.label}</option>
-                    ))}
-                </select>
+                <LanguageSelector value={language} onChange={(l) => setLanguage(l)} />
             </div>
             <div className="row">
                 {languages.filter(opt => opt.value !== 'auto').map(opt => (

--- a/ytapp/src/components/LanguageSelector.tsx
+++ b/ytapp/src/components/LanguageSelector.tsx
@@ -1,0 +1,42 @@
+import React, { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { languages, Language } from '../features/languages';
+
+interface LanguageSelectorProps {
+    value: Language;
+    onChange: (lang: Language) => void;
+}
+
+const LanguageSelector: React.FC<LanguageSelectorProps> = ({ value, onChange }) => {
+    const { t } = useTranslation();
+    const [search, setSearch] = useState('');
+    const [filter, setFilter] = useState('');
+
+    useEffect(() => {
+        const id = setTimeout(() => setFilter(search), 300);
+        return () => clearTimeout(id);
+    }, [search]);
+
+    const filtered = languages.filter(l =>
+        l.label.toLowerCase().includes(filter.toLowerCase())
+    );
+
+    return (
+        <div>
+            <input
+                aria-label={t('font_search')}
+                placeholder={t('font_search')}
+                value={search}
+                onChange={e => setSearch(e.target.value)}
+                style={{ width: '100%', marginBottom: 4 }}
+            />
+            <select value={value} onChange={e => onChange(e.target.value as Language)}>
+                {filtered.map(l => (
+                    <option key={l.value} value={l.value}>{l.label}</option>
+                ))}
+            </select>
+        </div>
+    );
+};
+
+export default LanguageSelector;

--- a/ytapp/src/components/ProfilesPage.tsx
+++ b/ytapp/src/components/ProfilesPage.tsx
@@ -2,6 +2,8 @@
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { listProfiles, getProfile, saveProfile, deleteProfile } from '../features/profiles';
+import { open, save } from '@tauri-apps/plugin-dialog';
+import { readTextFile, writeTextFile } from '@tauri-apps/plugin-fs';
 import type { Profile } from '../schema';
 
 interface ProfilesPageProps {
@@ -125,6 +127,19 @@ const ProfilesPage: React.FC<ProfilesPageProps> = ({ onLoad }) => {
             <div className="row">
                 <input type="color" value={profile.captionOptions?.color || '#ffffff'} onChange={handleCaptionChange('color')} />
                 <input type="color" value={profile.captionOptions?.background || '#000000'} onChange={handleCaptionChange('background')} />
+            </div>
+            <div className="row">
+                <button onClick={async () => {
+                    const path = await open({ filters: [{ name: 'JSON', extensions: ['json'] }] });
+                    if (typeof path === 'string') {
+                        const txt = await readTextFile(path);
+                        try { setProfile(JSON.parse(txt) as Profile); } catch { }
+                    }
+                }}>Import JSON</button>
+                <button onClick={async () => {
+                    const path = await save({ filters: [{ name: 'JSON', extensions: ['json'] }] });
+                    if (path) await writeTextFile(path, JSON.stringify(profile, null, 2));
+                }}>Export JSON</button>
             </div>
             <div className="row">
                 <button onClick={handleSave}>{t('save_profile')}</button>

--- a/ytapp/src/components/SettingsPage.tsx
+++ b/ytapp/src/components/SettingsPage.tsx
@@ -23,6 +23,7 @@ const SettingsPage: React.FC = () => {
     const [watchDir, setWatchDir] = useState('');
     const [autoUpload, setAutoUpload] = useState(false);
     const [modelSize, setModelSize] = useState('base');
+    const [output, setOutput] = useState('');
 
     useEffect(() => {
         loadSettings().then(s => {
@@ -40,6 +41,7 @@ const SettingsPage: React.FC = () => {
             setGuide(s.showGuide !== false);
             setWatchDir(s.watchDir || '');
             setAutoUpload(!!s.autoUpload);
+            setOutput(s.output || '');
             if (s.modelSize) setModelSize(s.modelSize);
         });
     }, []);
@@ -60,6 +62,7 @@ const SettingsPage: React.FC = () => {
             showGuide: guide,
             watchDir: watchDir || undefined,
             autoUpload,
+            output: output || undefined,
             modelSize,
         });
     };
@@ -99,6 +102,17 @@ const SettingsPage: React.FC = () => {
                     filters={[{ name: 'Media', extensions: ['mp4', 'mov', 'mkv', 'png', 'jpg', 'jpeg'] }]}
                 />
                 {outro && <span>{outro}</span>}
+            </div>
+            <div>
+                <FilePicker
+                    label="Output"
+                    onSelect={p => {
+                        if (typeof p === 'string') setOutput(p);
+                        else if (Array.isArray(p) && p.length) setOutput(p[0]);
+                    }}
+                    filters={[{ name: 'Video', extensions: ['mp4'] }]}
+                />
+                {output && <span>{output}</span>}
             </div>
             <div>
                 <FilePicker

--- a/ytapp/src/features/settings/index.ts
+++ b/ytapp/src/features/settings/index.ts
@@ -16,6 +16,7 @@ export interface Settings {
     showGuide?: boolean;
     watchDir?: string;
     autoUpload?: boolean;
+    output?: string;
     modelSize?: string;
 }
 


### PR DESCRIPTION
## Summary
- configure built‑in Tauri updater
- add searchable `LanguageSelector` component
- expose output video path on main screen and settings page
- allow profile JSON import/export
- document new features

## Testing
- `npm install` in `ytapp`
- `cargo check` in `ytapp/src-tauri`
- `npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_684f7313d0288331b0fbea547b23f2ca