### PR TITLE
Fix settings serialization

### DIFF
--- a/ytapp/src-tauri/src/main.rs
+++ b/ytapp/src-tauri/src/main.rs
@@ -65,6 +65,7 @@ struct UploadOptions {
 }
 
 #[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 struct AppSettings {
     intro: Option<String>,
     outro: Option<String>,

--- a/ytapp/src-tauri/src/model_check.rs
+++ b/ytapp/src-tauri/src/model_check.rs
@@ -7,6 +7,7 @@ use whisper_cli::{Model, Size};
 
 /// Ensure the default Whisper model is present. Downloads it if missing.
 #[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct PartialSettings {
     model_size: Option<String>,
 }


### PR DESCRIPTION
## Summary
- ensure settings struct serializes in camelCase
- use camelCase keys when reading model size

## Testing
- `npm install`
- `cargo check`
- `npx ts-node src/cli.ts --help`


------
https://chatgpt.com/codex/tasks/task_e_684f7a97135c83319b0de4bf4b288fe3