### PR TITLE
Add configurable maxRetries setting

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -396,7 +396,7 @@ Process all queued jobs (retry failed jobs with `--retry-failed`):
 ```bash
 npx ts-node src/cli.ts queue-run --retry-failed
 ```
-The maximum retry count is configured by `max_retries` in `settings.json` (default `3`).
+The maximum retry count is configurable in the Settings page or by `max_retries` in `settings.json` (default `3`).
 
 Profiles can store commonly used generation options in `settings.json`.
 Save a profile from a JSON file:

--- a/ytapp/public/locales/en/translation.json
+++ b/ytapp/public/locales/en/translation.json
@@ -58,6 +58,7 @@
   "edit_captions": "Edit Captions",
   "watch_directory": "Watch Directory",
   "auto_upload": "Auto Upload",
+  "max_retries": "Max Retries",
   "watching": "Watching",
   "not_watching": "Not Watching",
   "start_watch": "Start Watching",

--- a/ytapp/src/components/SettingsPage.tsx
+++ b/ytapp/src/components/SettingsPage.tsx
@@ -24,6 +24,7 @@ const SettingsPage: React.FC = () => {
     const [autoUpload, setAutoUpload] = useState(false);
     const [modelSize, setModelSize] = useState('base');
     const [output, setOutput] = useState('');
+    const [maxRetries, setMaxRetries] = useState(3);
 
     useEffect(() => {
         loadSettings().then(s => {
@@ -43,6 +44,7 @@ const SettingsPage: React.FC = () => {
             setAutoUpload(!!s.autoUpload);
             setOutput(s.output || '');
             if (s.modelSize) setModelSize(s.modelSize);
+            if (typeof s.maxRetries === 'number') setMaxRetries(s.maxRetries);
         });
     }, []);
 
@@ -64,6 +66,7 @@ const SettingsPage: React.FC = () => {
             autoUpload,
             output: output || undefined,
             modelSize,
+            maxRetries,
         });
     };
 
@@ -169,6 +172,10 @@ const SettingsPage: React.FC = () => {
                 <input type="text" value={watchDir} onChange={e => setWatchDir(e.target.value)} />
                 <label>{t('auto_upload')}</label>
                 <input type="checkbox" checked={autoUpload} onChange={e => setAutoUpload(e.target.checked)} />
+            </div>
+            <div>
+                <label>{t('max_retries')}</label>
+                <input type="number" min="1" value={maxRetries} onChange={e => setMaxRetries(parseInt(e.target.value, 10) || 1)} />
             </div>
             <button onClick={handleSave}>{t('save')}</button>
         </div>

--- a/ytapp/src/features/settings/index.ts
+++ b/ytapp/src/features/settings/index.ts
@@ -18,6 +18,7 @@ export interface Settings {
     autoUpload?: boolean;
     output?: string;
     modelSize?: string;
+    maxRetries?: number;
 }
 
 export async function loadSettings(): Promise<Settings> {


### PR DESCRIPTION
## Summary
- expose maxRetries option in Settings feature and page
- add translation string for max retries
- document setting in README

## Testing
- `cd ytapp && npm install`
- `cd src-tauri && cargo check`
- `cd .. && npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_684f7a9b22908331bb3688e6cf8ce6d9