### PR TITLE
Install clang for Tauri builds

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -240,6 +240,7 @@ Use the matching dependency script for your OS which installs GTK/WebKit
 packages and writes `.env.tauri`:
 
 * Linux: `scripts/install_tauri_deps.sh`
+  - Requires `clang` and `libclang-dev` on Linux; the script installs them automatically.
 * macOS: `scripts/install_tauri_deps_macos.sh`
 * Windows (PowerShell): `scripts/install_tauri_deps_windows.ps1`
 

--- a/scripts/install_tauri_deps.sh
+++ b/scripts/install_tauri_deps.sh
@@ -13,6 +13,7 @@ DEPS=(
     build-essential
     pkg-config
     libssl-dev
+    clang
 )
 
 if ! command -v apt-get >/dev/null; then
@@ -21,6 +22,15 @@ if ! command -v apt-get >/dev/null; then
 fi
 
 sudo apt-get update
+
+# Determine the libclang development package to install.
+LIBCLANG_PKG=$(apt-cache search --names-only '^libclang-[0-9]+-dev$' | \
+    sort -V | grep -o 'libclang-[0-9]*-dev' | tail -n1)
+if [ -z "$LIBCLANG_PKG" ]; then
+    LIBCLANG_PKG="libclang-dev"
+fi
+DEPS+=("$LIBCLANG_PKG")
+
 sudo apt-get install -y "${DEPS[@]}"
 
 PKGCONFIG_DIR=/usr/lib/x86_64-linux-gnu/pkgconfig


### PR DESCRIPTION
## Summary
- install `clang` and the appropriate `libclang-dev` package on Linux
- mention Clang requirement in the setup docs

## Testing
- `npm install`
- `cargo check`
- `npx ts-node src/cli.ts --help`


------
https://chatgpt.com/codex/tasks/task_e_684f8ab71dc48331ab0766bd14760d38