### PR TITLE
Fix playlist list type mismatch

### DIFF
--- a/ytapp/src-tauri/src/main.rs
+++ b/ytapp/src-tauri/src/main.rs
@@ -641,7 +641,7 @@ async fn list_playlists() -> Result<Vec<PlaylistInfo>, String> {
 
     let resp = hub
         .playlists()
-        .list(&["snippet".to_string()])
+        .list(&vec!["snippet".to_string()])
         .mine(true)
         .max_results(50)
         .doit()


### PR DESCRIPTION
## Summary
- fix argument type for YouTube playlist listing

## Testing
- `npm install`
- `cargo check`
- `npx ts-node src/cli.ts --help`
- `make verify`

------
https://chatgpt.com/codex/tasks/task_e_684f913c33208331909ad4f0ac8a6f69