### PR TITLE
Fix build by installing CMake

### DIFF
--- a/scripts/install_tauri_deps.sh
+++ b/scripts/install_tauri_deps.sh
@@ -14,6 +14,7 @@ DEPS=(
     pkg-config
     libssl-dev
     clang
+    cmake
 )
 
 if ! command -v apt-get >/dev/null; then


### PR DESCRIPTION
## Summary
- install `cmake` in `install_tauri_deps.sh`

## Testing
- `make verify` *(fails: Cannot find module '@tauri-apps/api/updater' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68507023222c833185cd2e3f226f5cfa