### PR TITLE
Fix missing emit_all import

### DIFF
--- a/ytapp/src-tauri/src/job_queue.rs
+++ b/ytapp/src-tauri/src/job_queue.rs
@@ -4,6 +4,7 @@ use std::sync::{Mutex, Arc};
 use tokio::sync::Notify;
 use serde::{Serialize, Deserialize};
 use tauri::api::path::app_config_dir;
+use tauri::Manager;
 
 use crate::schema::GenerateParams;
 use crate::logger;


### PR DESCRIPTION
## Summary
- import `tauri::Manager` in job_queue

## Testing
- `npm install` within `ytapp`
- `cargo check` within `ytapp/src-tauri`
- `npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_685075df1e108331a2f441c451277393