### PR TITLE
Implement queue item removal

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -379,6 +379,10 @@ Show queued jobs:
 ```bash
 npx ts-node src/cli.ts queue-list
 ```
+Remove a job by its index:
+```bash
+npx ts-node src/cli.ts queue-remove 0
+```
 Each job now tracks a `status` and `retries` count in `queue.json`.
 Failed jobs remain in the queue until they succeed or exceed the retry limit.
 

--- a/ytapp/public/locales/en/translation.json
+++ b/ytapp/public/locales/en/translation.json
@@ -73,6 +73,7 @@
   "load": "Load",
   "edit": "Edit",
   "clear_completed": "Clear Completed",
+  "remove": "Remove",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/src-tauri/src/job_queue.rs
+++ b/ytapp/src-tauri/src/job_queue.rs
@@ -100,6 +100,17 @@ pub fn mark_failed(app: &tauri::AppHandle, index: usize, error: String) -> Resul
     Ok(())
 }
 
+/// Remove a job from the queue by index.
+pub fn remove_job(app: &tauri::AppHandle, index: usize) -> Result<(), String> {
+    let mut q = QUEUE.lock().unwrap();
+    if index < q.len() {
+        q.remove(index);
+    }
+    save_queue(app)?;
+    emit_changed(app);
+    Ok(())
+}
+
 pub fn peek_all() -> Vec<QueueItem> {
     let q = QUEUE.lock().unwrap();
     q.clone()

--- a/ytapp/src-tauri/src/main.rs
+++ b/ytapp/src-tauri/src/main.rs
@@ -953,6 +953,13 @@ fn queue_clear(app: tauri::AppHandle) -> Result<(), String> {
 }
 
 #[command]
+fn queue_remove(app: tauri::AppHandle, index: usize) -> Result<(), String> {
+    load_queue(&app).ok();
+    log(&app, "info", "queue_remove");
+    job_queue::remove_job(&app, index)
+}
+
+#[command]
 fn queue_clear_completed(app: tauri::AppHandle) -> Result<(), String> {
     load_queue(&app).ok();
     log(&app, "info", "queue_clear_completed");
@@ -1252,7 +1259,7 @@ fn main() {
             }
             Ok(())
         })
-        .invoke_handler(tauri::generate_handler![generate_video, upload_video, upload_videos, transcribe_audio, generate_upload, generate_batch_upload, watch_directory, youtube_sign_in, youtube_sign_out, youtube_is_signed_in, list_playlists, load_settings, save_settings, load_srt, save_srt, cancel_generate, cancel_upload, queue_add, queue_list, queue_clear, queue_clear_completed, queue_process, profile_list, profile_get, profile_save, profile_delete, verify_dependencies, install_tauri_deps, list_fonts])
+        .invoke_handler(tauri::generate_handler![generate_video, upload_video, upload_videos, transcribe_audio, generate_upload, generate_batch_upload, watch_directory, youtube_sign_in, youtube_sign_out, youtube_is_signed_in, list_playlists, load_settings, save_settings, load_srt, save_srt, cancel_generate, cancel_upload, queue_add, queue_list, queue_remove, queue_clear, queue_clear_completed, queue_process, profile_list, profile_get, profile_save, profile_delete, verify_dependencies, install_tauri_deps, list_fonts])
         .run(context)
         .expect("error while running tauri application");
 }

--- a/ytapp/src/cli.ts
+++ b/ytapp/src/cli.ts
@@ -11,7 +11,7 @@ import { translateSrt } from './utils/translate';
 import { parseCsv, CsvRow } from './utils/csv';
 import { watchDirectory } from './features/watch';
 import { generateBatchWithProgress } from './features/batch';
-import { addJob, listJobs, runQueue, clearQueue, clearCompleted } from './features/queue';
+import { addJob, listJobs, runQueue, clearQueue, clearCompleted, removeJob } from './features/queue';
 import { listProfiles, getProfile, saveProfile, deleteProfile } from './features/profiles';
 import type { Profile } from './schema';
 import { verifyDependencies } from './features/dependencies';
@@ -914,6 +914,19 @@ program
       console.log(JSON.stringify(jobs, null, 2));
     } catch (err) {
       console.error('Error listing queue:', err);
+      process.exitCode = 1;
+    }
+  });
+
+program
+  .command('queue-remove')
+  .description('Remove a job from the queue by index')
+  .argument('<index>', 'job index')
+  .action(async (index: string) => {
+    try {
+      await removeJob(parseInt(index, 10));
+    } catch (err) {
+      console.error('Error removing job:', err);
       process.exitCode = 1;
     }
   });

--- a/ytapp/src/components/QueuePage.tsx
+++ b/ytapp/src/components/QueuePage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { listJobs, runQueue, clearCompleted, clearQueue, listenQueue } from '../features/queue';
+import { listJobs, runQueue, clearCompleted, clearQueue, listenQueue, removeJob } from '../features/queue';
 
 const QueuePage: React.FC = () => {
   const { t } = useTranslation();
@@ -32,6 +32,7 @@ const QueuePage: React.FC = () => {
           <span>{JSON.stringify(j.job)}</span>
           <span>{j.status}</span>
           <span>{j.retries}</span>
+          <button onClick={() => removeJob(i).then(refresh)}>{t('remove')}</button>
         </div>
       ))}
     </div>

--- a/ytapp/src/features/queue.ts
+++ b/ytapp/src/features/queue.ts
@@ -21,6 +21,11 @@ export async function listJobs(): Promise<QueueItem[]> {
   return await invoke('queue_list');
 }
 
+/** Remove a job at the specified index. */
+export async function removeJob(index: number): Promise<void> {
+  await invoke('queue_remove', { index });
+}
+
 /** Clear all jobs from the queue. */
 export async function clearQueue(): Promise<void> {
   await invoke('queue_clear');


### PR DESCRIPTION
## Summary
- add `queue_remove` command in Rust backend and CLI
- update queue feature to call new command
- add remove button in queue page
- add "remove" translation string
- document queue removal in README

## Testing
- `npm install`
- `cargo check`
- `npx ts-node src/cli.ts --help`


------
https://chatgpt.com/codex/tasks/task_e_68508f5e949c8331bc1ab6508b654d99