### PR TITLE
Fix missing Clone for QueueProgress

### DIFF
--- a/ytapp/src-tauri/src/main.rs
+++ b/ytapp/src-tauri/src/main.rs
@@ -47,7 +47,7 @@ struct SystemFont {
     path: String,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 struct QueueProgress {
     index: usize,
     progress: f64,


### PR DESCRIPTION
## Summary
- derive `Clone` for `QueueProgress`

## Testing
- `cd ytapp && npm install`
- `cd src-tauri && cargo check`
- `cd .. && npx ts-node src/cli.ts --help`


------
https://chatgpt.com/codex/tasks/task_e_6850d6879bf08331992224c35ba4f48d