### PR TITLE
Add queue pause/resume controls

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -401,6 +401,12 @@ Process all queued jobs (retry failed jobs with `--retry-failed`):
 ```bash
 npx ts-node src/cli.ts queue-run --retry-failed
 ```
+Pause or resume queue processing:
+
+```bash
+npx ts-node src/cli.ts queue-pause
+npx ts-node src/cli.ts queue-resume
+```
 The maximum retry count is configurable in the Settings page or by `max_retries` in `settings.json` (default `3`).
 
 Profiles can store commonly used generation options in `settings.json`.

--- a/ytapp/src-tauri/src/main.rs
+++ b/ytapp/src-tauri/src/main.rs
@@ -47,7 +47,7 @@ struct SystemFont {
     path: String,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 struct QueueProgress {
     index: usize,
     progress: f64,
@@ -988,18 +988,37 @@ fn queue_clear_completed(app: tauri::AppHandle) -> Result<(), String> {
 }
 
 #[command]
+fn queue_pause(_app: tauri::AppHandle) {
+    job_queue::set_paused(true);
+    job_queue::notifier().notify_one();
+}
+
+#[command]
+fn queue_resume(_app: tauri::AppHandle) {
+    job_queue::set_paused(false);
+    job_queue::notifier().notify_one();
+}
+
+#[command]
 async fn queue_process(window: Window, retry_failed: Option<bool>) -> Result<(), String> {
     let app = window.app_handle();
     load_queue(&app).ok();
     let settings = load_settings(app.clone()).unwrap_or_default();
     let max_retries = settings.max_retries.unwrap_or(3);
     let retry = retry_failed.unwrap_or(false);
-    while let Some((idx, item)) = dequeue(&app, retry, max_retries)? {
-        let res: Result<(), String> = match item.job {
-            Job::Generate { mut params, dest } => {
-                params.output = Some(dest);
-                generate_video(window.clone(), params, Some(idx)).map(|_| ())
-            }
+    let notify = notifier();
+    loop {
+        if job_queue::is_paused() {
+            notify.notified().await;
+            continue;
+        }
+        let maybe = dequeue(&app, retry, max_retries)?;
+        if let Some((idx, item)) = maybe {
+            let res: Result<(), String> = match item.job {
+                Job::Generate { mut params, dest } => {
+                    params.output = Some(dest);
+                    generate_video(window.clone(), params, Some(idx)).map(|_| ())
+                }
             Job::GenerateUpload { mut params, dest, thumbnail } => {
                 params.output = Some(dest);
                 if params.thumbnail.is_none() { params.thumbnail = thumbnail.clone(); }
@@ -1009,6 +1028,9 @@ async fn queue_process(window: Window, retry_failed: Option<bool>) -> Result<(),
         match res {
             Ok(_) => { mark_complete(&app, idx)?; log(&app, "info", "job_complete"); },
             Err(e) => { log(&app, "error", &e); mark_failed(&app, idx, e)?; },
+        }
+        } else {
+            break;
         }
     }
     Ok(())
@@ -1026,6 +1048,10 @@ fn start_queue_worker(window: Window) {
             load_queue(&app).ok();
             let settings = load_settings(app.clone()).unwrap_or_default();
             let max_retries = settings.max_retries.unwrap_or(3);
+            if job_queue::is_paused() {
+                notify.notified().await;
+                continue;
+            }
             if let Some((idx, item)) = dequeue(&app, true, max_retries).unwrap_or(None) {
                 let res: Result<(), String> = match item.job {
                     Job::Generate { mut params, dest } => {
@@ -1280,7 +1306,7 @@ fn main() {
             }
             Ok(())
         })
-        .invoke_handler(tauri::generate_handler![generate_video, upload_video, upload_videos, transcribe_audio, generate_upload, generate_batch_upload, watch_directory, youtube_sign_in, youtube_sign_out, youtube_is_signed_in, list_playlists, load_settings, save_settings, load_srt, save_srt, cancel_generate, cancel_upload, queue_add, queue_list, queue_remove, queue_move, queue_clear, queue_clear_completed, queue_process, profile_list, profile_get, profile_save, profile_delete, verify_dependencies, install_tauri_deps, list_fonts])
+        .invoke_handler(tauri::generate_handler![generate_video, upload_video, upload_videos, transcribe_audio, generate_upload, generate_batch_upload, watch_directory, youtube_sign_in, youtube_sign_out, youtube_is_signed_in, list_playlists, load_settings, save_settings, load_srt, save_srt, cancel_generate, cancel_upload, queue_add, queue_list, queue_remove, queue_move, queue_clear, queue_clear_completed, queue_pause, queue_resume, queue_process, profile_list, profile_get, profile_save, profile_delete, verify_dependencies, install_tauri_deps, list_fonts])
         .run(context)
         .expect("error while running tauri application");
 }

--- a/ytapp/src/cli.ts
+++ b/ytapp/src/cli.ts
@@ -11,7 +11,7 @@ import { translateSrt } from './utils/translate';
 import { parseCsv, CsvRow } from './utils/csv';
 import { watchDirectory } from './features/watch';
 import { generateBatchWithProgress } from './features/batch';
-import { addJob, listJobs, runQueue, clearQueue, clearCompleted, removeJob } from './features/queue';
+import { addJob, listJobs, runQueue, clearQueue, clearCompleted, removeJob, pauseQueue, resumeQueue } from './features/queue';
 import { listProfiles, getProfile, saveProfile, deleteProfile } from './features/profiles';
 import type { Profile } from './schema';
 import { verifyDependencies } from './features/dependencies';
@@ -965,6 +965,30 @@ program
       await runQueue(!!opts.retryFailed);
     } catch (err) {
       console.error('Error running queue:', err);
+      process.exitCode = 1;
+    }
+  });
+
+program
+  .command('queue-pause')
+  .description('Pause queue processing')
+  .action(async () => {
+    try {
+      await pauseQueue();
+    } catch (err) {
+      console.error('Error pausing queue:', err);
+      process.exitCode = 1;
+    }
+  });
+
+program
+  .command('queue-resume')
+  .description('Resume queue processing')
+  .action(async () => {
+    try {
+      await resumeQueue();
+    } catch (err) {
+      console.error('Error resuming queue:', err);
       process.exitCode = 1;
     }
   });

--- a/ytapp/src/features/queue.ts
+++ b/ytapp/src/features/queue.ts
@@ -45,6 +45,14 @@ export async function runQueue(retryFailed = false): Promise<void> {
   await invoke('queue_process', { retryFailed });
 }
 
+export async function pauseQueue(): Promise<void> {
+  await invoke('queue_pause');
+}
+
+export async function resumeQueue(): Promise<void> {
+  await invoke('queue_resume');
+}
+
 export async function moveJob(from: number, to: number): Promise<void> {
   await invoke('queue_move', { from, to });
 }

--- a/ytapp/tests/queue.test.ts
+++ b/ytapp/tests/queue.test.ts
@@ -3,17 +3,31 @@ const core = require('@tauri-apps/api/core');
 
 (async () => {
   let q: any[] = [];
+  let paused = false;
   core.invoke = async (cmd: string, args: any) => {
     if (cmd === 'queue_add') { q.push({ job: args.job, status: 'pending', retries: 0 }); return; }
     if (cmd === 'queue_list') { return q; }
-    if (cmd === 'queue_process') { q = []; return; }
+    if (cmd === 'queue_process') { if (!paused) q = []; return; }
+    if (cmd === 'queue_pause') { paused = true; return; }
+    if (cmd === 'queue_resume') { paused = false; return; }
   };
-  const { addJob, listJobs, runQueue } = await import('../src/features/queue');
+  const { addJob, listJobs, runQueue, pauseQueue, resumeQueue } = await import('../src/features/queue');
   await addJob({ Generate: { params: { file: 'a.mp3' }, dest: 'a.mp4' } } as any);
   let jobs = await listJobs();
   assert.strictEqual(jobs.length, 1);
   await runQueue();
   jobs = await listJobs();
   assert.strictEqual(jobs.length, 0);
-  console.log('queue feature tests passed');
+
+  await addJob({ Generate: { params: { file: 'b.mp3' }, dest: 'b.mp4' } } as any);
+  await pauseQueue();
+  await runQueue();
+  jobs = await listJobs();
+  assert.strictEqual(jobs.length, 1);
+  await resumeQueue();
+  await runQueue();
+  jobs = await listJobs();
+  assert.strictEqual(jobs.length, 0);
+
+  console.log('queue tests passed');
 })();


### PR DESCRIPTION
## Summary
- add pause/resume flag to job queue
- expose queue_pause/queue_resume commands from backend and CLI
- implement pause/resume helpers in the frontend queue module
- document new CLI commands
- extend queue tests for pause/resume functionality

## Testing
- `npm install`
- `cargo check`
- `npx ts-node src/cli.ts --help`
- `npx ts-node tests/queue.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6850d69e72608331821fb3d38777b833