### PR TITLE
Add log viewer across app

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -198,6 +198,7 @@ If `cargo check` fails on Linux, run `scripts/install_tauri_deps.sh`.
    launch when a matching translation exists. Contributions to improve
    translations are welcome.
 * Video preview modal after generation
+* Logs page to view application logs
 
 ---
 
@@ -406,6 +407,11 @@ Pause or resume queue processing:
 ```bash
 npx ts-node src/cli.ts queue-pause
 npx ts-node src/cli.ts queue-resume
+```
+View recent logs:
+
+```bash
+npx ts-node src/cli.ts logs 200
 ```
 The maximum retry count is configurable in the Settings page or by `max_retries` in `settings.json` (default `3`).
 

--- a/ytapp/public/locales/en/translation.json
+++ b/ytapp/public/locales/en/translation.json
@@ -79,5 +79,7 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "logs": "Logs",
+  "refresh": "Refresh"
 }

--- a/ytapp/src-tauri/src/logger.rs
+++ b/ytapp/src-tauri/src/logger.rs
@@ -33,3 +33,14 @@ pub fn log(app: &tauri::AppHandle, level: &str, message: &str) {
         }
     }
 }
+
+pub fn read_logs(app: &tauri::AppHandle, max_lines: usize) -> Result<String, String> {
+    let path = match log_path(app) {
+        Ok(p) => p,
+        Err(e) => return Err(e),
+    };
+    let data = std::fs::read_to_string(path).map_err(|e| e.to_string())?;
+    let lines: Vec<&str> = data.lines().collect();
+    let start = lines.len().saturating_sub(max_lines);
+    Ok(lines[start..].join("\n"))
+}

--- a/ytapp/src-tauri/src/main.rs
+++ b/ytapp/src-tauri/src/main.rs
@@ -30,7 +30,7 @@ use token_store::EncryptedTokenStorage;
 mod job_queue;
 use job_queue::{Job, QueueItem, enqueue, dequeue, peek_all, load_queue, clear_queue as clear_in_memory, notifier, mark_complete, mark_failed};
 mod logger;
-use logger::log;
+use logger::{log, read_logs};
 use tauri::api::dialog::{blocking::MessageDialogBuilder, MessageDialogKind};
 use notify::{RecommendedWatcher, RecursiveMode, Watcher, Config, EventKind, Event, Error as NotifyError};
 use once_cell::sync::Lazy;
@@ -1296,6 +1296,11 @@ fn install_tauri_deps() -> Result<(), String> {
     }
 }
 
+#[command]
+fn get_logs(app: tauri::AppHandle, max_lines: Option<usize>) -> Result<String, String> {
+    read_logs(&app, max_lines.unwrap_or(200))
+}
+
 fn main() {
     let context = tauri::generate_context!();
     ensure_whisper_model(&context.config());
@@ -1306,7 +1311,7 @@ fn main() {
             }
             Ok(())
         })
-        .invoke_handler(tauri::generate_handler![generate_video, upload_video, upload_videos, transcribe_audio, generate_upload, generate_batch_upload, watch_directory, youtube_sign_in, youtube_sign_out, youtube_is_signed_in, list_playlists, load_settings, save_settings, load_srt, save_srt, cancel_generate, cancel_upload, queue_add, queue_list, queue_remove, queue_move, queue_clear, queue_clear_completed, queue_pause, queue_resume, queue_process, profile_list, profile_get, profile_save, profile_delete, verify_dependencies, install_tauri_deps, list_fonts])
+        .invoke_handler(tauri::generate_handler![generate_video, upload_video, upload_videos, transcribe_audio, generate_upload, generate_batch_upload, watch_directory, youtube_sign_in, youtube_sign_out, youtube_is_signed_in, list_playlists, load_settings, save_settings, load_srt, save_srt, cancel_generate, cancel_upload, queue_add, queue_list, queue_remove, queue_move, queue_clear, queue_clear_completed, queue_pause, queue_resume, queue_process, profile_list, profile_get, profile_save, profile_delete, verify_dependencies, install_tauri_deps, list_fonts, get_logs])
         .run(context)
         .expect("error while running tauri application");
 }

--- a/ytapp/src/App.tsx
+++ b/ytapp/src/App.tsx
@@ -31,13 +31,14 @@ import SubtitleEditor from './components/SubtitleEditor';
 import { notify } from './utils/notify';
 import UpdateModal from './components/UpdateModal';
 import QueuePage from './components/QueuePage';
+import LogsPage from './components/LogsPage';
 import HelpOverlay from './components/HelpOverlay';
 import { check } from '@tauri-apps/plugin-updater';
 import { relaunch } from '@tauri-apps/plugin-process';
 
 const App: React.FC = () => {
     const { t, i18n } = useTranslation();
-    const [page, setPage] = useState<'single' | 'batch' | 'settings' | 'profiles' | 'queue'>('single');
+    const [page, setPage] = useState<'single' | 'batch' | 'settings' | 'profiles' | 'queue' | 'logs'>('single');
     const [file, setFile] = useState('');
     const [background, setBackground] = useState('');
     const [captions, setCaptions] = useState('');
@@ -380,6 +381,17 @@ const App: React.FC = () => {
         );
     }
 
+    if (page === 'logs') {
+        return (
+            <div className="app">
+                <div className="row">
+                    <button onClick={() => setPage('single')}>{t('back')}</button>
+                </div>
+                <LogsPage />
+            </div>
+        );
+    }
+
     return (
         <div className="app">
             <h1>{t('title')}</h1>
@@ -598,6 +610,7 @@ const App: React.FC = () => {
                     {t('settings')}
                 </button>
                 <button onClick={() => setPage('queue')}>{t('queue')}</button>
+                <button onClick={() => setPage('logs')}>{t('logs')}</button>
             </div>
             {generating && (
                 <div className="row">

--- a/ytapp/src/cli.ts
+++ b/ytapp/src/cli.ts
@@ -15,6 +15,7 @@ import { addJob, listJobs, runQueue, clearQueue, clearCompleted, removeJob, paus
 import { listProfiles, getProfile, saveProfile, deleteProfile } from './features/profiles';
 import type { Profile } from './schema';
 import { verifyDependencies } from './features/dependencies';
+import { getLogs } from './features/logs';
 
 async function callWithProgress<T>(
   fn: () => Promise<T>,
@@ -989,6 +990,21 @@ program
       await resumeQueue();
     } catch (err) {
       console.error('Error resuming queue:', err);
+      process.exitCode = 1;
+    }
+  });
+
+program
+  .command('logs')
+  .description('Print recent log entries')
+  .argument('[maxLines]', 'number of lines to show')
+  .action(async (maxLines: string | undefined) => {
+    try {
+      const n = parseInt(maxLines || '', 10);
+      const text = await getLogs(isNaN(n) ? 100 : n);
+      console.log(text);
+    } catch (err) {
+      console.error('Error reading logs:', err);
       process.exitCode = 1;
     }
   });

--- a/ytapp/src/components/LogsPage.tsx
+++ b/ytapp/src/components/LogsPage.tsx
@@ -1,0 +1,25 @@
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { getLogs } from '../features/logs';
+
+const LogsPage: React.FC = () => {
+    const { t } = useTranslation();
+    const [text, setText] = useState('');
+
+    const refresh = () => {
+        getLogs(200).then(setText).catch(() => setText(''));
+    };
+
+    useEffect(() => {
+        refresh();
+    }, []);
+
+    return (
+        <div>
+            <button onClick={refresh}>{t('refresh')}</button>
+            <pre style={{ whiteSpace: 'pre-wrap', maxHeight: '70vh', overflow: 'auto' }}>{text}</pre>
+        </div>
+    );
+};
+
+export default LogsPage;

--- a/ytapp/src/features/logs.ts
+++ b/ytapp/src/features/logs.ts
@@ -1,0 +1,7 @@
+// Wrapper around Tauri command for reading log files.
+import { invoke } from '@tauri-apps/api/core';
+
+/** Retrieve recent log lines from the backend. */
+export async function getLogs(maxLines = 200): Promise<string> {
+  return await invoke('get_logs', { maxLines });
+}


### PR DESCRIPTION
## Summary
- read backend logs via `read_logs` and expose `get_logs`
- implement `get_logs` command in CLI
- add `LogsPage` component and menu entry
- document logs feature in README
- update English translations

## Testing
- `npm install`
- `cargo check` *(fails: glib-2.0 not found)*
- `npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_68513c72911483318cf6424883d5dbfd