### PR TITLE
Enhance UI with queue control and help overlay

### DIFF
--- a/ytapp/public/locales/en/help.json
+++ b/ytapp/public/locales/en/help.json
@@ -6,5 +6,30 @@
     "Batch Tools let you process multiple files at once.",
     "Open Settings for more options and watch directory support."
   ],
+  "main": {
+    "title": "Workflow Help",
+    "lines": [
+      "Select audio then click Generate to create your video."
+    ]
+  },
+  "batch": {
+    "title": "Batch Help",
+    "lines": [
+      "Batch Processor handles multiple files and Batch Upload posts them."
+    ]
+  },
+  "queue": {
+    "title": "Queue Help",
+    "lines": [
+      "Process Queue runs all pending jobs.",
+      "Pause stops processing until resumed."
+    ]
+  },
+  "settings_page": {
+    "title": "Settings Help",
+    "lines": [
+      "Save default values for captions and watch directory."
+    ]
+  },
   "close": "Close"
 }

--- a/ytapp/public/locales/en/translation.json
+++ b/ytapp/public/locales/en/translation.json
@@ -81,5 +81,9 @@
   "playlist": "Playlist",
   "font_search": "Search fonts...",
   "logs": "Logs",
-  "refresh": "Refresh"
+  "refresh": "Refresh",
+  "help": "Help",
+  "pause": "Pause",
+  "resume": "Resume",
+  "solarized": "Solarized"
 }

--- a/ytapp/src/App.tsx
+++ b/ytapp/src/App.tsx
@@ -33,6 +33,7 @@ import UpdateModal from './components/UpdateModal';
 import QueuePage from './components/QueuePage';
 import LogsPage from './components/LogsPage';
 import HelpOverlay from './components/HelpOverlay';
+import HelpIcon from './components/HelpIcon';
 import { check } from '@tauri-apps/plugin-updater';
 import { relaunch } from '@tauri-apps/plugin-process';
 
@@ -55,9 +56,9 @@ const App: React.FC = () => {
     const [language, setLanguage] = useState<Language>('auto');
     const [width, setWidth] = useState(1280);
     const [height, setHeight] = useState(720);
-    const [theme, setTheme] = useState<'light' | 'dark' | 'high'>(() => {
+    const [theme, setTheme] = useState<'light' | 'dark' | 'high' | 'solarized'>(() => {
         const stored = localStorage.getItem('theme');
-        if (stored === 'dark' || stored === 'high' || stored === 'light') {
+        if (stored === 'dark' || stored === 'high' || stored === 'light' || stored === 'solarized') {
             return stored as any;
         }
         return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
@@ -71,6 +72,7 @@ const App: React.FC = () => {
     const [preview, setPreview] = useState('');
     const [showGuide, setShowGuide] = useState(false);
     const [showHelp, setShowHelp] = useState(false);
+    const [helpPage, setHelpPage] = useState('main');
     const [showUpdate, setShowUpdate] = useState(false);
     const [title, setTitle] = useState('');
     const [description, setDescription] = useState('');
@@ -123,7 +125,15 @@ const App: React.FC = () => {
     }, [i18n.language]);
 
     const toggleTheme = () =>
-        setTheme(theme === 'light' ? 'dark' : theme === 'dark' ? 'high' : 'light');
+        setTheme(
+            theme === 'light'
+                ? 'dark'
+                : theme === 'dark'
+                ? 'high'
+                : theme === 'high'
+                ? 'solarized'
+                : 'light'
+        );
 
 
     const handleTranscriptionComplete = (srts: string[]) => {
@@ -328,6 +338,7 @@ const App: React.FC = () => {
                     setPage('settings');
                     e.preventDefault();
                 } else if (e.key === 'h') {
+                    setHelpPage(page);
                     setShowHelp(true);
                     e.preventDefault();
                 }
@@ -342,6 +353,9 @@ const App: React.FC = () => {
             <div className="app">
                 <div className="row">
                     <button onClick={() => setPage('single')}>{t('back')}</button>
+                    <button onClick={() => { setHelpPage('batch'); setShowHelp(true); }} aria-label={t('help')}>
+                        <HelpIcon />
+                    </button>
                 </div>
                 <BatchPage />
             </div>
@@ -364,6 +378,9 @@ const App: React.FC = () => {
             <div className="app">
                 <div className="row">
                     <button onClick={() => setPage('single')}>{t('back')}</button>
+                    <button onClick={() => { setHelpPage('settings_page'); setShowHelp(true); }} aria-label={t('help')}>
+                        <HelpIcon />
+                    </button>
                 </div>
                 <SettingsPage />
             </div>
@@ -375,6 +392,9 @@ const App: React.FC = () => {
             <div className="app">
                 <div className="row">
                     <button onClick={() => setPage('single')}>{t('back')}</button>
+                    <button onClick={() => { setHelpPage('queue'); setShowHelp(true); }} aria-label={t('help')}>
+                        <HelpIcon />
+                    </button>
                 </div>
                 <QueuePage />
             </div>
@@ -398,6 +418,9 @@ const App: React.FC = () => {
             <div className="row">
                 <LanguageSelector value={i18n.language as Language} onChange={l => i18n.changeLanguage(l)} />
                 <button onClick={toggleTheme}>{t('toggle_theme')}</button>
+                <button onClick={() => { setHelpPage('main'); setShowHelp(true); }} aria-label={t('help')}>
+                    <HelpIcon />
+                </button>
             </div>
             <div className="row">
                 <FilePicker label={t('select_audio')} useDropZone onSelect={(p) => {
@@ -645,7 +668,7 @@ const App: React.FC = () => {
             </Modal>
             <WatchStatus />
             <div aria-live="polite" className="sr-only">{announcement}</div>
-            <HelpOverlay open={showHelp} onClose={() => setShowHelp(false)} />
+            <HelpOverlay page={helpPage} open={showHelp} onClose={() => setShowHelp(false)} />
             <UpdateModal open={showUpdate} onUpdate={handleUpdateApp} onClose={() => setShowUpdate(false)} />
             <OnboardingModal open={showGuide} onClose={dismissGuide} />
         </div>

--- a/ytapp/src/components/CaptionPreview.tsx
+++ b/ytapp/src/components/CaptionPreview.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+interface CaptionPreviewProps {
+    font: string;
+    size: number;
+    color: string;
+    background: string;
+    position: string;
+}
+
+const CaptionPreview: React.FC<CaptionPreviewProps> = ({ font, size, color, background, position }) => {
+    const containerStyle: React.CSSProperties = {
+        position: 'relative',
+        width: '100%',
+        height: 80,
+        background: '#222',
+        marginTop: 8,
+    };
+
+    const captionStyle: React.CSSProperties = {
+        position: 'absolute',
+        left: '50%',
+        transform: 'translateX(-50%)',
+        fontFamily: font || 'inherit',
+        fontSize: size,
+        color,
+        backgroundColor: background,
+        padding: '2px 4px',
+    };
+
+    if (position === 'top') captionStyle.top = 4;
+    else if (position === 'center') {
+        captionStyle.top = '50%';
+        captionStyle.transform = 'translate(-50%, -50%)';
+    } else captionStyle.bottom = 4;
+
+    return (
+        <div style={containerStyle} aria-hidden="true">
+            <div style={captionStyle}>Sample Caption</div>
+        </div>
+    );
+};
+
+export default CaptionPreview;

--- a/ytapp/src/components/HelpIcon.tsx
+++ b/ytapp/src/components/HelpIcon.tsx
@@ -1,0 +1,23 @@
+// Question mark icon used to open help dialogs.
+import React from 'react';
+
+const HelpIcon: React.FC<{className?: string}> = ({ className }) => (
+  <svg
+    className={className}
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <circle cx="12" cy="12" r="10" />
+    <path d="M9 9a3 3 0 0 1 6 0c0 1.5-2 2-2 2" />
+    <line x1="12" y1="17" x2="12" y2="17" />
+  </svg>
+);
+
+export default HelpIcon;

--- a/ytapp/src/components/HelpOverlay.tsx
+++ b/ytapp/src/components/HelpOverlay.tsx
@@ -4,16 +4,19 @@ import Modal from './Modal';
 
 interface HelpOverlayProps {
   open: boolean;
+  page?: string;
   onClose: () => void;
 }
 
-const HelpOverlay: React.FC<HelpOverlayProps> = ({ open, onClose }) => {
+const HelpOverlay: React.FC<HelpOverlayProps> = ({ open, page, onClose }) => {
   const { t } = useTranslation('help');
   if (!open) return null;
-  const lines: string[] = t('lines', { returnObjects: true }) as any;
+  const titleKey = page ? `${page}.title` : 'title';
+  const linesKey = page ? `${page}.lines` : 'lines';
+  const lines: string[] = t(linesKey, { returnObjects: true }) as any;
   return (
     <Modal open={open} onClose={onClose}>
-      <h2>{t('title')}</h2>
+      <h2>{t(titleKey)}</h2>
       <ul>
         {lines.map((l, i) => (
           <li key={i}>{l}</li>

--- a/ytapp/src/components/QueuePage.tsx
+++ b/ytapp/src/components/QueuePage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { listJobs, runQueue, clearCompleted, clearQueue, listenQueue, removeJob, listenProgress, moveJob, QueueProgress } from '../features/queue';
+import { listJobs, runQueue, pauseQueue, resumeQueue, clearCompleted, clearQueue, listenQueue, removeJob, listenProgress, moveJob, QueueProgress } from '../features/queue';
 
 const QueuePage: React.FC = () => {
   const { t } = useTranslation();
@@ -32,6 +32,12 @@ const QueuePage: React.FC = () => {
     <div>
       <h2>{t('queue')}</h2>
       <button onClick={() => runQueue().then(refresh)}>{t('process_queue')}</button>
+      <button onClick={() => pauseQueue().then(refresh)} aria-label={t('pause')}>
+        {t('pause')}
+      </button>
+      <button onClick={() => resumeQueue().then(refresh)} aria-label={t('resume')}>
+        {t('resume')}
+      </button>
       <button onClick={() => clearCompleted().then(refresh)}>{t('clear_completed')}</button>
       <button onClick={() => clearQueue().then(refresh)}>{t('clear_all')}</button>
       {jobs.map((j, i) => (

--- a/ytapp/src/components/SettingsPage.tsx
+++ b/ytapp/src/components/SettingsPage.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import FilePicker from './FilePicker';
 import FontSelector from './FontSelector';
 import SizeSlider from './SizeSlider';
+import CaptionPreview from './CaptionPreview';
 import { loadSettings, saveSettings } from '../features/settings';
 
 const SettingsPage: React.FC = () => {
@@ -157,6 +158,13 @@ const SettingsPage: React.FC = () => {
                 <label>{t('caption_bg')}</label>
                 <input type="color" value={captionBg} onChange={e => setCaptionBg(e.target.value)} />
             </div>
+            <CaptionPreview
+                font={font}
+                size={size}
+                color={captionColor}
+                background={captionBg}
+                position="bottom"
+            />
             <div>
                 <label>{t('whisper_size')}</label>
                 <select value={modelSize} onChange={e => setModelSize(e.target.value)}>

--- a/ytapp/src/theme.css
+++ b/ytapp/src/theme.css
@@ -38,3 +38,14 @@
   --transition: 0.2s ease;
   --focus-color: #fff;
 }
+[data-theme="solarized"] {
+  --bg-color: #fdf6e3;
+  --text-color: #657b83;
+  --button-bg: #eee8d5;
+  --button-text: #586e75;
+  --button-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  --spacing-8: 0.5rem;
+  --spacing: calc(var(--spacing-8) * 3);
+  --transition: 0.2s ease;
+  --focus-color: #b58900;
+}


### PR DESCRIPTION
## Summary
- add pause and resume buttons on the queue page
- introduce solarized theme and cycle theme through all modes
- embed contextual help buttons and overlay support
- provide caption preview on the settings page
- localize new labels

## Testing
- `npm install`
- `cargo check` *(fails: system library `glib-2.0` not found)*
- `npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_68513cd96f688331a8d7143c6e215184