### PR TITLE
Add watermark and accent features

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -178,6 +178,8 @@ If `cargo check` fails on Linux, run `scripts/install_tauri_deps.sh`.
   * Font selector
   * Size slider
   * Position (top / center / bottom)
+  * Watermark opacity and scale controls
+  * Custom accent color setting
 * YouTube sign-in/sign-out buttons
 * Generate video button
 * Generate & upload to YouTube button

--- a/ytapp/public/locales/en/translation.json
+++ b/ytapp/public/locales/en/translation.json
@@ -41,6 +41,8 @@
   "whisper_size": "Whisper Model Size",
   "watermark": "Watermark",
   "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale",
   "top_left": "Top Left",
   "top_right": "Top Right",
   "bottom_left": "Bottom Left",

--- a/ytapp/src-tauri/src/main.rs
+++ b/ytapp/src-tauri/src/main.rs
@@ -84,6 +84,7 @@ struct AppSettings {
     caption_size: Option<u32>,
     caption_color: Option<String>,
     caption_bg: Option<String>,
+    accent_color: Option<String>,
     watermark: Option<String>,
     watermark_position: Option<String>,
     show_guide: Option<bool>,
@@ -106,6 +107,7 @@ impl Default for AppSettings {
             caption_size: None,
             caption_color: None,
             caption_bg: None,
+            accent_color: None,
             watermark: None,
             watermark_position: None,
             show_guide: Some(true),
@@ -393,10 +395,14 @@ fn build_main_section(window: Option<&Window>, params: &GenerateParams, duration
                 "bottom-left" => "10:H-h-10",
                 _ => "W-w-10:H-h-10",
             };
+            let scale = params.watermark_scale.unwrap_or(0.2);
+            let opacity = params.watermark_opacity.unwrap_or(1.0);
             filter_chain = format!(
-                "{},movie={},scale=iw/5:-1[wm];[in][wm]overlay={}",
+                "{},movie={},scale=iw*{:.3}:-1,format=rgba,colorchannelmixer=aa={:.3}[wm];[in][wm]overlay={}",
                 filter_chain,
                 escape_filter_path(wm),
+                scale,
+                opacity,
                 pos
             );
         }
@@ -791,6 +797,8 @@ async fn generate_batch_upload(window: Window, params: BatchGenerateParams) -> R
             background: params.background.clone(),
             watermark: params.watermark.clone(),
             watermark_position: params.watermark_position.clone(),
+            watermark_opacity: params.watermark_opacity,
+            watermark_scale: params.watermark_scale,
             intro: params.intro.clone(),
             outro: params.outro.clone(),
             width: params.width,
@@ -849,10 +857,12 @@ fn watch_directory(window: Window, params: WatchDirectoryParams) -> Result<(), S
                                         captions: opts.captions.clone(),
                                         caption_options: opts.caption_options.clone(),
                                         background: opts.background.clone(),
-                                        watermark: opts.watermark.clone(),
-                                        watermark_position: opts.watermark_position.clone(),
-                                        intro: opts.intro.clone(),
-                                        outro: opts.outro.clone(),
+                                       watermark: opts.watermark.clone(),
+                                       watermark_position: opts.watermark_position.clone(),
+                                        watermark_opacity: opts.watermark_opacity,
+                                        watermark_scale: opts.watermark_scale,
+                                       intro: opts.intro.clone(),
+                                       outro: opts.outro.clone(),
                                         width: opts.width,
                                         height: opts.height,
                                         title: opts.title.clone(),

--- a/ytapp/src-tauri/src/schema.rs
+++ b/ytapp/src-tauri/src/schema.rs
@@ -23,6 +23,10 @@ pub struct Profile {
     pub watermark: Option<String>,
     #[serde(rename = "watermarkPosition")]
     pub watermark_position: Option<String>,
+    #[serde(rename = "watermarkOpacity")]
+    pub watermark_opacity: Option<f32>,
+    #[serde(rename = "watermarkScale")]
+    pub watermark_scale: Option<f32>,
     pub width: Option<u32>,
     pub height: Option<u32>,
     pub title: Option<String>,
@@ -49,6 +53,10 @@ pub struct GenerateParams {
     pub watermark: Option<String>,
     #[serde(rename = "watermarkPosition")]
     pub watermark_position: Option<String>,
+    #[serde(rename = "watermarkOpacity")]
+    pub watermark_opacity: Option<f32>,
+    #[serde(rename = "watermarkScale")]
+    pub watermark_scale: Option<f32>,
     pub width: Option<u32>,
     pub height: Option<u32>,
     pub title: Option<String>,

--- a/ytapp/src/App.tsx
+++ b/ytapp/src/App.tsx
@@ -46,6 +46,8 @@ const App: React.FC = () => {
     const [outro, setOutro] = useState('');
     const [watermark, setWatermark] = useState('');
     const [watermarkPos, setWatermarkPos] = useState<'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'>('top-right');
+    const [watermarkOpacity, setWatermarkOpacity] = useState(1);
+    const [watermarkScale, setWatermarkScale] = useState(0.2);
     const [translations, setTranslations] = useState<string[]>([]);
     const [font, setFont] = useState('');
     const [fontPath, setFontPath] = useState('');
@@ -64,6 +66,7 @@ const App: React.FC = () => {
     });
     const [captionColor, setCaptionColor] = useState('#ffffff');
     const [captionBg, setCaptionBg] = useState('#000000');
+    const [accentColor, setAccentColor] = useState('#ff9500');
     const [progress, setProgress] = useState(0);
     const [announcement, setAnnouncement] = useState('');
     const [generating, setGenerating] = useState(false);
@@ -95,6 +98,7 @@ const App: React.FC = () => {
             if (s.captionSize) setSize(s.captionSize);
             if (s.captionColor) setCaptionColor(s.captionColor);
             if (s.captionBg) setCaptionBg(s.captionBg);
+            if (s.accentColor) setAccentColor(s.accentColor);
             if (s.watermark) setWatermark(s.watermark);
             if (s.watermarkPosition) setWatermarkPos(s.watermarkPosition as any);
             if (s.output) setOutput(s.output);
@@ -116,6 +120,10 @@ const App: React.FC = () => {
         document.documentElement.setAttribute('data-theme', theme);
         localStorage.setItem('theme', theme);
     }, [theme]);
+
+    useEffect(() => {
+        document.documentElement.style.setProperty('--accent-color', accentColor);
+    }, [accentColor]);
 
     useEffect(() => {
         const lang = languages.find(l => l.value === i18n.language);
@@ -150,6 +158,8 @@ const App: React.FC = () => {
             background: background || undefined,
             watermark: watermark || undefined,
             watermarkPosition: watermarkPos,
+            watermarkOpacity,
+            watermarkScale,
             intro: intro || undefined,
             outro: outro || undefined,
             width,
@@ -181,6 +191,8 @@ const App: React.FC = () => {
         background: background || undefined,
         watermark: watermark || undefined,
         watermarkPosition: watermarkPos,
+        watermarkOpacity,
+        watermarkScale,
         intro: intro || undefined,
         outro: outro || undefined,
         width,
@@ -213,6 +225,8 @@ const App: React.FC = () => {
             outro: outro || undefined,
             watermark: watermark || undefined,
             watermarkPosition: watermarkPos,
+            watermarkOpacity,
+            watermarkScale,
             width,
             height,
             title: title || undefined,
@@ -263,6 +277,8 @@ const App: React.FC = () => {
         setCaptions(p.captions || '');
         setWatermark(p.watermark || '');
         if (p.watermarkPosition) setWatermarkPos(p.watermarkPosition as any);
+        if (typeof p.watermarkOpacity === 'number') setWatermarkOpacity(p.watermarkOpacity);
+        if (typeof p.watermarkScale === 'number') setWatermarkScale(p.watermarkScale);
         if (p.captionOptions) {
             setFont(p.captionOptions.font || '');
             setFontPath(p.captionOptions.fontPath || '');
@@ -446,6 +462,12 @@ const App: React.FC = () => {
                     <option value="bottom-left">{t('bottom_left')}</option>
                     <option value="bottom-right">{t('bottom_right')}</option>
                 </select>
+            </div>
+            <div className="row">
+                <label>{t('watermark_opacity')}</label>
+                <input type="number" min="0" max="1" step="0.05" value={watermarkOpacity} onChange={e => setWatermarkOpacity(parseFloat(e.target.value))} />
+                <label>{t('watermark_scale')}</label>
+                <input type="number" min="0" max="1" step="0.05" value={watermarkScale} onChange={e => setWatermarkScale(parseFloat(e.target.value))} />
             </div>
             <div className="row">
                 <TranscribeButton

--- a/ytapp/src/cli.ts
+++ b/ytapp/src/cli.ts
@@ -236,6 +236,8 @@ program
   .option('-b, --background <file>', 'background image or video')
   .option('--watermark <file>', 'watermark image')
   .option('--watermark-position <pos>', 'watermark position (top-left|top-right|bottom-left|bottom-right)')
+  .option('--watermark-opacity <n>', 'watermark opacity (0-1)', (v) => parseFloat(v))
+  .option('--watermark-scale <n>', 'watermark scale relative to width', (v) => parseFloat(v))
   .option('--intro <file>', 'intro video or image')
   .option('--outro <file>', 'outro video or image')
   .option('--width <width>', 'output width', (v) => parseInt(v, 10))
@@ -267,6 +269,8 @@ program
         outro: options.outro,
         watermark: options.watermark,
         watermarkPosition: options.watermarkPosition,
+        watermarkOpacity: options.watermarkOpacity,
+        watermarkScale: options.watermarkScale,
         width: options.width,
         height: options.height,
         title: options.title,
@@ -311,6 +315,8 @@ program
   .option('-b, --background <file>', 'background image or video')
   .option('--watermark <file>', 'watermark image')
   .option('--watermark-position <pos>', 'watermark position (top-left|top-right|bottom-left|bottom-right)')
+  .option('--watermark-opacity <n>', 'watermark opacity (0-1)', (v) => parseFloat(v))
+  .option('--watermark-scale <n>', 'watermark scale relative to width', (v) => parseFloat(v))
   .option('--intro <file>', 'intro video or image')
   .option('--outro <file>', 'outro video or image')
   .option('--width <width>', 'output width', (v) => parseInt(v, 10))
@@ -336,6 +342,8 @@ program
         background: options.background,
         watermark: options.watermark,
         watermarkPosition: options.watermarkPosition,
+        watermarkOpacity: options.watermarkOpacity,
+        watermarkScale: options.watermarkScale,
         intro: options.intro,
         outro: options.outro,
         width: options.width,
@@ -380,6 +388,8 @@ program
   .option('-b, --background <file>', 'background image or video')
   .option('--watermark <file>', 'watermark image')
   .option('--watermark-position <pos>', 'watermark position (top-left|top-right|bottom-left|bottom-right)')
+  .option('--watermark-opacity <n>', 'watermark opacity (0-1)', (v) => parseFloat(v))
+  .option('--watermark-scale <n>', 'watermark scale relative to width', (v) => parseFloat(v))
   .option('--intro <file>', 'intro video or image')
   .option('--outro <file>', 'outro video or image')
   .option('--width <width>', 'output width', (v) => parseInt(v, 10))
@@ -409,6 +419,8 @@ program
         background: options.background,
         watermark: options.watermark,
         watermarkPosition: options.watermarkPosition,
+        watermarkOpacity: options.watermarkOpacity,
+        watermarkScale: options.watermarkScale,
         intro: options.intro,
         outro: options.outro,
         width: options.width,
@@ -451,6 +463,8 @@ program
   .option('-b, --background <file>', 'background image or video')
   .option('--watermark <file>', 'watermark image')
   .option('--watermark-position <pos>', 'watermark position (top-left|top-right|bottom-left|bottom-right)')
+  .option('--watermark-opacity <n>', 'watermark opacity (0-1)', (v) => parseFloat(v))
+  .option('--watermark-scale <n>', 'watermark scale relative to width', (v) => parseFloat(v))
   .option('--intro <file>', 'intro video or image')
   .option('--outro <file>', 'outro video or image')
   .option('--width <width>', 'output width', (v) => parseInt(v, 10))
@@ -497,6 +511,8 @@ program
             background: options.background,
             watermark: options.watermark,
             watermarkPosition: options.watermarkPosition,
+            watermarkOpacity: options.watermarkOpacity,
+            watermarkScale: options.watermarkScale,
             intro: options.intro,
             outro: options.outro,
             width: options.width,
@@ -532,6 +548,8 @@ program
                 background: options.background,
                 watermark: options.watermark,
                 watermarkPosition: options.watermarkPosition,
+                watermarkOpacity: options.watermarkOpacity,
+                watermarkScale: options.watermarkScale,
                 intro: options.intro,
                 outro: options.outro,
                 width: options.width,
@@ -574,6 +592,8 @@ program
   .option('-b, --background <file>', 'background image or video')
   .option('--watermark <file>', 'watermark image')
   .option('--watermark-position <pos>', 'watermark position (top-left|top-right|bottom-left|bottom-right)')
+  .option('--watermark-opacity <n>', 'watermark opacity (0-1)', (v) => parseFloat(v))
+  .option('--watermark-scale <n>', 'watermark scale relative to width', (v) => parseFloat(v))
   .option('--intro <file>', 'intro video or image')
   .option('--outro <file>', 'outro video or image')
   .option('--width <width>', 'output width', (v) => parseInt(v, 10))
@@ -867,6 +887,8 @@ program
   .option('-b, --background <file>', 'background image or video')
   .option('--watermark <file>', 'watermark image')
   .option('--watermark-position <pos>', 'watermark position (top-left|top-right|bottom-left|bottom-right)')
+  .option('--watermark-opacity <n>', 'watermark opacity (0-1)', (v) => parseFloat(v))
+  .option('--watermark-scale <n>', 'watermark scale relative to width', (v) => parseFloat(v))
   .option('--intro <file>', 'intro video or image')
   .option('--outro <file>', 'outro video or image')
   .option('--width <width>', 'output width', (v) => parseInt(v, 10))
@@ -894,6 +916,8 @@ program
       background: options.background,
       watermark: options.watermark,
       watermarkPosition: options.watermarkPosition,
+      watermarkOpacity: options.watermarkOpacity,
+      watermarkScale: options.watermarkScale,
       intro: options.intro,
       outro: options.outro,
       width: options.width,

--- a/ytapp/src/components/BatchOptionsForm.tsx
+++ b/ytapp/src/components/BatchOptionsForm.tsx
@@ -51,6 +51,12 @@ const BatchOptionsForm: React.FC<BatchOptionsFormProps> = ({ value, onChange }) 
                 </select>
             </div>
             <div className="row">
+                <label>{t('watermark_opacity')}</label>
+                <input type="number" min="0" max="1" step="0.05" value={value.watermarkOpacity ?? 1} onChange={e => update({ watermarkOpacity: parseFloat(e.target.value) })} />
+                <label>{t('watermark_scale')}</label>
+                <input type="number" min="0" max="1" step="0.05" value={value.watermarkScale ?? 0.2} onChange={e => update({ watermarkScale: parseFloat(e.target.value) })} />
+            </div>
+            <div className="row">
                 <FilePicker
                     label={t('intro')}
                     onSelect={(p) => {

--- a/ytapp/src/components/ProfilesPage.tsx
+++ b/ytapp/src/components/ProfilesPage.tsx
@@ -53,7 +53,7 @@ const ProfilesPage: React.FC<ProfilesPageProps> = ({ onLoad }) => {
 
     const handleNumberChange = (key: keyof Profile) => (e: React.ChangeEvent<HTMLInputElement>) => {
         const val = e.target.value;
-        setProfile(prev => ({ ...prev, [key]: val ? parseInt(val, 10) : undefined }));
+        setProfile(prev => ({ ...prev, [key]: val ? Number(val) : undefined }));
     };
 
     const handleCaptionChange = (key: keyof NonNullable<Profile['captionOptions']>) => (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -93,6 +93,10 @@ const ProfilesPage: React.FC<ProfilesPageProps> = ({ onLoad }) => {
             </div>
             <div className="row">
                 <input type="text" placeholder="Watermark Position" value={profile.watermarkPosition || ''} onChange={handleProfileChange('watermarkPosition')} />
+            </div>
+            <div className="row">
+                <input type="number" step="0.05" placeholder="Opacity" value={profile.watermarkOpacity ?? 1} onChange={handleNumberChange('watermarkOpacity')} />
+                <input type="number" step="0.05" placeholder="Scale" value={profile.watermarkScale ?? 0.2} onChange={handleNumberChange('watermarkScale')} />
             </div>
             <div className="row">
                 <input type="number" placeholder="Width" value={profile.width || ''} onChange={handleNumberChange('width')} />

--- a/ytapp/src/components/SettingsPage.tsx
+++ b/ytapp/src/components/SettingsPage.tsx
@@ -17,6 +17,7 @@ const SettingsPage: React.FC = () => {
     const [size, setSize] = useState(24);
     const [captionColor, setCaptionColor] = useState('#ffffff');
     const [captionBg, setCaptionBg] = useState('#000000');
+    const [accentColor, setAccentColor] = useState('#ff9500');
     const [watermark, setWatermark] = useState('');
     const [watermarkPos, setWatermarkPos] = useState<'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'>('top-right');
     const [guide, setGuide] = useState(true);
@@ -37,6 +38,7 @@ const SettingsPage: React.FC = () => {
             setSize(s.captionSize || 24);
             if (s.captionColor) setCaptionColor(s.captionColor);
             if (s.captionBg) setCaptionBg(s.captionBg);
+            if (s.accentColor) setAccentColor(s.accentColor);
             if (s.watermark) setWatermark(s.watermark);
             if (s.watermarkPosition) setWatermarkPos(s.watermarkPosition as any);
             setGuide(s.showGuide !== false);
@@ -67,6 +69,7 @@ const SettingsPage: React.FC = () => {
             output: output || undefined,
             modelSize,
             maxRetries,
+            accentColor,
         });
     };
 
@@ -156,6 +159,8 @@ const SettingsPage: React.FC = () => {
                 <input type="color" value={captionColor} onChange={e => setCaptionColor(e.target.value)} />
                 <label>{t('caption_bg')}</label>
                 <input type="color" value={captionBg} onChange={e => setCaptionBg(e.target.value)} />
+                <label>Accent</label>
+                <input type="color" value={accentColor} onChange={e => setAccentColor(e.target.value)} />
             </div>
             <div>
                 <label>{t('whisper_size')}</label>

--- a/ytapp/src/components/SubtitleEditor.tsx
+++ b/ytapp/src/components/SubtitleEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import { loadSrt, saveSrt } from '../features/transcription';
 
 interface SubtitleEditorProps {
@@ -10,12 +10,32 @@ interface SubtitleEditorProps {
 const SubtitleEditor: React.FC<SubtitleEditorProps> = ({ file, onClose, onSaved }) => {
     const [content, setContent] = useState('');
     const [error, setError] = useState<string | null>(null);
+    const [search, setSearch] = useState('');
+    const [replace, setReplace] = useState('');
+    const textareaRef = useRef<HTMLTextAreaElement>(null);
 
     useEffect(() => {
         loadSrt(file)
             .then(setContent)
             .catch(e => setError(String(e)));
     }, [file]);
+
+    useEffect(() => {
+        const handler = (e: KeyboardEvent) => {
+            if (e.ctrlKey || e.metaKey) {
+                if (e.key === 's') {
+                    e.preventDefault();
+                    handleSave();
+                } else if (e.key === 'f') {
+                    e.preventDefault();
+                    const input = document.getElementById('subtitle-search') as HTMLInputElement;
+                    input?.focus();
+                }
+            }
+        };
+        window.addEventListener('keydown', handler);
+        return () => window.removeEventListener('keydown', handler);
+    });
 
     const handleSave = async () => {
         try {
@@ -26,10 +46,23 @@ const SubtitleEditor: React.FC<SubtitleEditorProps> = ({ file, onClose, onSaved 
         }
     };
 
+    const handleReplace = (all: boolean) => {
+        if (!search) return;
+        const regex = new RegExp(search, 'g');
+        setContent(c => all ? c.replace(regex, replace) : c.replace(search, replace));
+    };
+
     return (
         <div>
             {error && <div>{error}</div>}
+            <div className="row">
+                <input id="subtitle-search" type="text" placeholder="Search" value={search} onChange={e => setSearch(e.target.value)} />
+                <input type="text" placeholder="Replace" value={replace} onChange={e => setReplace(e.target.value)} />
+                <button onClick={() => handleReplace(false)}>Replace</button>
+                <button onClick={() => handleReplace(true)}>Replace All</button>
+            </div>
             <textarea
+                ref={textareaRef}
                 style={{ width: '100%', height: '60vh' }}
                 value={content}
                 onChange={e => setContent(e.target.value)}

--- a/ytapp/src/features/batch/index.ts
+++ b/ytapp/src/features/batch/index.ts
@@ -11,6 +11,8 @@ export interface BatchOptions extends Omit<GenerateParams, 'file' | 'output'> {
     background?: string;
     watermark?: string;
     watermarkPosition?: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+    watermarkOpacity?: number;
+    watermarkScale?: number;
 }
 
 // Derive an output file path based on the input file and optional directory.
@@ -29,6 +31,8 @@ async function generateOne(file: string, options: BatchOptions): Promise<string>
         background: options.background,
         watermark: options.watermark,
         watermarkPosition: options.watermarkPosition,
+        watermarkOpacity: options.watermarkOpacity,
+        watermarkScale: options.watermarkScale,
         intro: options.intro,
         outro: options.outro,
         width: options.width,

--- a/ytapp/src/features/settings/index.ts
+++ b/ytapp/src/features/settings/index.ts
@@ -11,6 +11,7 @@ export interface Settings {
     captionSize?: number;
     captionColor?: string;
     captionBg?: string;
+    accentColor?: string;
     watermark?: string;
     watermarkPosition?: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
     showGuide?: boolean;

--- a/ytapp/src/schema.ts
+++ b/ytapp/src/schema.ts
@@ -16,6 +16,8 @@ export interface Profile {
   outro?: string;
   watermark?: string;
   watermarkPosition?: string;
+  watermarkOpacity?: number;
+  watermarkScale?: number;
   width?: number;
   height?: number;
   title?: string;
@@ -37,6 +39,8 @@ export interface GenerateParams {
   outro?: string;
   watermark?: string;
   watermarkPosition?: string;
+  watermarkOpacity?: number;
+  watermarkScale?: number;
   width?: number;
   height?: number;
   title?: string;

--- a/ytapp/src/theme.css
+++ b/ytapp/src/theme.css
@@ -1,6 +1,7 @@
 :root {
   --bg-color: #f5f5f5;
   --text-color: #333;
+  --accent-color: #ff9500;
   --button-bg: #ffffff;
   --button-text: #333;
   --button-radius: 4px;
@@ -8,18 +9,19 @@
   --spacing-8: 0.5rem;
   --spacing: calc(var(--spacing-8) * 3);
   --transition: 0.2s ease;
-  --focus-color: #ff9500;
+  --focus-color: var(--accent-color);
 }
 [data-theme="dark"] {
   --bg-color: #333;
   --text-color: #f5f5f5;
+  --accent-color: #ff9500;
   --button-bg: #444;
   --button-text: #f5f5f5;
   --button-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
   --spacing-8: 0.5rem;
   --spacing: calc(var(--spacing-8) * 3);
   --transition: 0.2s ease;
-  --focus-color: #ff9500;
+  --focus-color: var(--accent-color);
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -30,11 +32,12 @@
 [data-theme="high"] {
   --bg-color: #000;
   --text-color: #fff;
+  --accent-color: #fff;
   --button-bg: #000;
   --button-text: #fff;
   --button-shadow: none;
   --spacing-8: 0.5rem;
   --spacing: calc(var(--spacing-8) * 3);
   --transition: 0.2s ease;
-  --focus-color: #fff;
+  --focus-color: var(--accent-color);
 }


### PR DESCRIPTION
## Summary
- allow configuring watermark opacity and scale via UI, CLI and backend
- add custom accent color setting with CSS variable and settings form
- enhance subtitle editor with search/replace and shortcuts
- document new controls in README

## Testing
- `npm install`
- `cargo check` *(fails: glib-2.0 missing)*
- `npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_68513cf3cf60833184d5e62bf34e52da