### PR TITLE
Add output path persistence setting

### DIFF
--- a/ytapp/src-tauri/src/main.rs
+++ b/ytapp/src-tauri/src/main.rs
@@ -89,6 +89,7 @@ struct AppSettings {
     show_guide: Option<bool>,
     watch_dir: Option<String>,
     auto_upload: Option<bool>,
+    output: Option<String>,
     model_size: Option<String>,
     max_retries: Option<u32>,
     profiles: HashMap<String, Profile>,
@@ -111,6 +112,7 @@ impl Default for AppSettings {
             show_guide: Some(true),
             watch_dir: None,
             auto_upload: Some(false),
+            output: None,
             model_size: Some("base".into()),
             max_retries: Some(3),
             profiles: HashMap::new(),
@@ -898,6 +900,9 @@ fn load_settings(app: tauri::AppHandle) -> Result<AppSettings, String> {
     }
     if settings.auto_upload.is_none() {
         settings.auto_upload = Some(false);
+    }
+    if settings.output.is_none() {
+        settings.output = None;
     }
     if settings.model_size.is_none() {
         settings.model_size = Some("base".into());

--- a/ytapp/src/App.tsx
+++ b/ytapp/src/App.tsx
@@ -252,6 +252,7 @@ const App: React.FC = () => {
             captionBg: captionBg,
             watermark: watermark || undefined,
             watermarkPosition: watermarkPos,
+            output: output || undefined,
             showGuide: false,
         });
     };

--- a/ytapp/tests/settings.test.ts
+++ b/ytapp/tests/settings.test.ts
@@ -1,0 +1,17 @@
+import assert from 'assert';
+const core = require('@tauri-apps/api/core');
+
+(async () => {
+  core.invoke = async (cmd: string, args: any) => {
+    if (cmd === 'load_settings') return { output: '/tmp/out.mp4' };
+    if (cmd === 'save_settings') {
+      assert.strictEqual(args.settings.output, '/tmp/out.mp4');
+      return;
+    }
+  };
+  const { loadSettings, saveSettings } = await import('../src/features/settings');
+  const s = await loadSettings();
+  assert.strictEqual(s.output, '/tmp/out.mp4');
+  await saveSettings({ output: '/tmp/out.mp4' });
+  console.log('settings feature tests passed');
+})();


### PR DESCRIPTION
## Summary
- persist `output` field in AppSettings
- include output when saving settings from the app
- test Settings feature persistence

## Testing
- `cd ytapp && npm install`
- `cd src-tauri && cargo check`
- `cd .. && npx ts-node src/cli.ts --help`
- `for f in ytapp/tests/*.ts; do npx ts-node "$f"; done` *(fails: ts-node not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68513c79eebc8331995f8f1c3a1ec827