### PR TITLE
Add ability to save logs

### DIFF
--- a/ytapp/public/locales/en/translation.json
+++ b/ytapp/public/locales/en/translation.json
@@ -84,6 +84,7 @@
   "font_search": "Search fonts...",
   "logs": "Logs",
   "refresh": "Refresh",
+  "save_logs": "Save Logs",
   "help": "Help",
   "pause": "Pause",
   "resume": "Resume",

--- a/ytapp/src/components/LogsPage.tsx
+++ b/ytapp/src/components/LogsPage.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getLogs } from '../features/logs';
+import { save } from '@tauri-apps/plugin-dialog';
+import { writeTextFile } from '@tauri-apps/plugin-fs';
 
 const LogsPage: React.FC = () => {
     const { t } = useTranslation();
@@ -10,6 +12,14 @@ const LogsPage: React.FC = () => {
         getLogs(200).then(setText).catch(() => setText(''));
     };
 
+    const saveLogs = async () => {
+        const path = await save({ filters: [{ name: 'Log', extensions: ['log'] }] });
+        if (path) {
+            const data = await getLogs(1000);
+            await writeTextFile(path, data);
+        }
+    };
+
     useEffect(() => {
         refresh();
     }, []);
@@ -17,6 +27,7 @@ const LogsPage: React.FC = () => {
     return (
         <div>
             <button onClick={refresh}>{t('refresh')}</button>
+            <button onClick={saveLogs}>{t('save_logs')}</button>
             <pre style={{ whiteSpace: 'pre-wrap', maxHeight: '70vh', overflow: 'auto' }}>{text}</pre>
         </div>
     );


### PR DESCRIPTION
## Summary
- add Save Logs button in LogsPage
- add matching translation string

## Testing
- `npm install`
- `cargo check`
- `npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_6853088f9a2083318711631d5c22adb0