### PR TITLE
Enhance font preview and queue notifications

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -232,6 +232,10 @@ required GTK/WebKit packages. It also writes `.env.tauri` which defines
 After the script finishes **source `.env.tauri` or restart your shell** so
 the variables are available before running any Cargo commands.
 
+The application automatically verifies that FFmpeg and Whisper are installed at
+startup. To run this check manually use:
+`npx ts-node src/cli.ts check-deps`
+
 ```bash
 git clone https://github.com/letapicode/YoutubeAutomation.git
 cd YoutubeAutomation

--- a/ytapp/src/App.tsx
+++ b/ytapp/src/App.tsx
@@ -673,11 +673,12 @@ const App: React.FC = () => {
             ))}
             <Modal open={!!preview} onClose={closePreview}>
                 {preview && (
-                    <video
-                        src={convertFileSrc(preview)}
-                        controls
-                        style={{ maxWidth: '100%', maxHeight: '80vh' }}
-                    />
+                    <div className="video-preview">
+                        <video
+                            src={convertFileSrc(preview)}
+                            controls
+                        />
+                    </div>
                 )}
             </Modal>
             <Modal open={showEditor} onClose={() => setShowEditor(false)}>

--- a/ytapp/src/components/DropZone.tsx
+++ b/ytapp/src/components/DropZone.tsx
@@ -23,7 +23,12 @@ const DropZone: React.FC<DropZoneProps> = ({ onDropFiles, acceptExt, multiple = 
     });
 
     return (
-        <div {...getRootProps()} className="dropzone">
+        <div
+            {...getRootProps()}
+            className="dropzone"
+            role="button"
+            tabIndex={0}
+        >
             <input {...getInputProps()} />
             {isDragActive ? 'Drop files here...' : label || 'Drag & drop files here'}
         </div>

--- a/ytapp/src/components/FontSelector.tsx
+++ b/ytapp/src/components/FontSelector.tsx
@@ -66,10 +66,16 @@ const FontSelector: React.FC<FontSelectorProps> = ({ value, onChange }) => {
             <select value={currentValue} onChange={handleChange} aria-label="Font selector">
                 <option value="">{t('default')}</option>
                 {filteredFonts.map(f => (
-                    <option key={f.path} value={f.path}>{`${f.name} (${f.style})`}</option>
+                    <option
+                        key={f.path}
+                        value={f.path}
+                        style={{ fontFamily: f.name }}
+                    >{`${f.name} (${f.style})`}</option>
                 ))}
                 {value?.path && !fonts.find(f => f.path === value.path) && (
-                    <option value={value.path}>{basename(value.path)}</option>
+                    <option value={value.path} style={{ fontFamily: value.name }}>
+                        {basename(value.path)}
+                    </option>
                 )}
                 <option value="__custom__">{t('select_file')}</option>
             </select>

--- a/ytapp/src/components/Modal.tsx
+++ b/ytapp/src/components/Modal.tsx
@@ -11,7 +11,12 @@ const Modal: React.FC<ModalProps> = ({ open, onClose, children }) => {
     if (!open) return null;
     return (
         <div className="modal-overlay" onClick={onClose}>
-            <div className="modal" onClick={e => e.stopPropagation()}>
+            <div
+                className="modal"
+                onClick={e => e.stopPropagation()}
+                role="dialog"
+                aria-modal="true"
+            >
                 <button className="close" onClick={onClose} aria-label="Close modal">×</button>
                 {children}
             </div>

--- a/ytapp/src/components/QueuePage.tsx
+++ b/ytapp/src/components/QueuePage.tsx
@@ -1,6 +1,21 @@
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { listJobs, runQueue, pauseQueue, resumeQueue, clearCompleted, clearQueue, listenQueue, removeJob, listenProgress, moveJob, QueueProgress } from '../features/queue';
+import {
+  listJobs,
+  runQueue,
+  pauseQueue,
+  resumeQueue,
+  clearCompleted,
+  clearQueue,
+  listenQueue,
+  removeJob,
+  listenProgress,
+  moveJob,
+  QueueProgress,
+  listenNotify,
+  QueueNotify,
+} from '../features/queue';
+import { notify } from '../utils/notify';
 
 const QueuePage: React.FC = () => {
   const { t } = useTranslation();
@@ -16,15 +31,21 @@ const QueuePage: React.FC = () => {
     refresh();
     let unlisten: (() => void) | undefined;
     let progUn: (() => void) | undefined;
+    let notifyUn: (() => void) | undefined;
     listenQueue(refresh).then((u) => {
       unlisten = u;
     });
     listenProgress((p: QueueProgress) => {
       setProgressMap(m => ({ ...m, [p.index]: p.progress }));
     }).then(u => { progUn = u; });
+    listenNotify((n: QueueNotify) => {
+      notify('Queue', n.success ? 'Job completed' : 'Job failed');
+      refresh();
+    }).then(u => { notifyUn = u; });
     return () => {
       if (unlisten) unlisten();
       if (progUn) progUn();
+      if (notifyUn) notifyUn();
     };
   }, []);
 

--- a/ytapp/src/components/SizeSlider.tsx
+++ b/ytapp/src/components/SizeSlider.tsx
@@ -15,6 +15,7 @@ const SizeSlider: React.FC<SizeSliderProps> = ({ value, onChange, min = 12, max 
         max={max}
         value={value}
         onChange={e => onChange(parseInt(e.target.value, 10))}
+        aria-label="Caption size"
     />
 );
 

--- a/ytapp/src/features/queue.ts
+++ b/ytapp/src/features/queue.ts
@@ -71,3 +71,18 @@ export async function listenQueue(onChange: () => void): Promise<() => void> {
     unlisten();
   };
 }
+
+export interface QueueNotify {
+  index: number;
+  success: boolean;
+  error?: string;
+}
+
+export async function listenNotify(onNotify: (n: QueueNotify) => void): Promise<() => void> {
+  const unlisten = await listen<QueueNotify>('queue_notify', e => {
+    if (e.payload) onNotify(e.payload as QueueNotify);
+  });
+  return () => {
+    unlisten();
+  };
+}

--- a/ytapp/src/theme.css
+++ b/ytapp/src/theme.css
@@ -52,3 +52,15 @@
   --transition: 0.2s ease;
   --focus-color: #b58900;
 }
+
+.video-preview {
+  background: var(--bg-color);
+  display: flex;
+  justify-content: center;
+}
+
+.video-preview video {
+  width: 100%;
+  height: auto;
+  max-height: 80vh;
+}


### PR DESCRIPTION
## Summary
- preview fonts in dropdown
- send desktop notifications for queue jobs
- improve accessibility for modal, slider and dropzone
- make video preview responsive and theme-aware
- document dependency check in README

## Testing
- `npm install`
- `cargo check` *(fails: gobject-sys)*
- `npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_6853089243408331ae96065c7915d189