### PR TITLE
Add UI font customization

### DIFF
--- a/ytapp/public/locales/en/translation.json
+++ b/ytapp/public/locales/en/translation.json
@@ -82,6 +82,7 @@
   "later": "Later",
   "playlist": "Playlist",
   "font_search": "Search fonts...",
+  "ui_font": "UI Font",
   "logs": "Logs",
   "refresh": "Refresh",
   "save_logs": "Save Logs",

--- a/ytapp/src/App.tsx
+++ b/ytapp/src/App.tsx
@@ -67,6 +67,7 @@ const App: React.FC = () => {
     });
     const [captionColor, setCaptionColor] = useState('#ffffff');
     const [captionBg, setCaptionBg] = useState('#000000');
+    const [uiFont, setUiFont] = useState('');
     const [accentColor, setAccentColor] = useState('#ff9500');
     const [progress, setProgress] = useState(0);
     const [announcement, setAnnouncement] = useState('');
@@ -100,6 +101,10 @@ const App: React.FC = () => {
             if (s.captionSize) setSize(s.captionSize);
             if (s.captionColor) setCaptionColor(s.captionColor);
             if (s.captionBg) setCaptionBg(s.captionBg);
+            if (s.uiFont) {
+                setUiFont(s.uiFont);
+                document.body.style.fontFamily = s.uiFont;
+            }
             if (s.accentColor) setAccentColor(s.accentColor);
             if (s.watermark) setWatermark(s.watermark);
             if (s.watermarkPosition) setWatermarkPos(s.watermarkPosition as any);
@@ -126,6 +131,10 @@ const App: React.FC = () => {
     useEffect(() => {
         document.documentElement.style.setProperty('--accent-color', accentColor);
     }, [accentColor]);
+
+    useEffect(() => {
+        document.body.style.fontFamily = uiFont || '';
+    }, [uiFont]);
 
     useEffect(() => {
         const lang = languages.find(l => l.value === i18n.language);

--- a/ytapp/src/components/SettingsPage.tsx
+++ b/ytapp/src/components/SettingsPage.tsx
@@ -18,6 +18,7 @@ const SettingsPage: React.FC = () => {
     const [size, setSize] = useState(24);
     const [captionColor, setCaptionColor] = useState('#ffffff');
     const [captionBg, setCaptionBg] = useState('#000000');
+    const [uiFont, setUiFont] = useState('');
     const [accentColor, setAccentColor] = useState('#ff9500');
     const [watermark, setWatermark] = useState('');
     const [watermarkPos, setWatermarkPos] = useState<'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'>('top-right');
@@ -39,6 +40,7 @@ const SettingsPage: React.FC = () => {
             setSize(s.captionSize || 24);
             if (s.captionColor) setCaptionColor(s.captionColor);
             if (s.captionBg) setCaptionBg(s.captionBg);
+            if (s.uiFont) setUiFont(s.uiFont);
             if (s.accentColor) setAccentColor(s.accentColor);
             if (s.watermark) setWatermark(s.watermark);
             if (s.watermarkPosition) setWatermarkPos(s.watermarkPosition as any);
@@ -62,6 +64,7 @@ const SettingsPage: React.FC = () => {
             captionSize: size,
             captionColor,
             captionBg,
+            uiFont: uiFont || undefined,
             watermark: watermark || undefined,
             watermarkPosition: watermarkPos,
             showGuide: guide,
@@ -72,6 +75,7 @@ const SettingsPage: React.FC = () => {
             maxRetries,
             accentColor,
         });
+        document.body.style.fontFamily = uiFont || '';
     };
 
     return (
@@ -149,6 +153,13 @@ const SettingsPage: React.FC = () => {
                         setFontPath(f?.path || '');
                         setFontStyle(f?.style || '');
                     }}
+                />
+            </div>
+            <div>
+                <label>{t('ui_font')}</label>
+                <FontSelector
+                    value={uiFont ? { name: uiFont } : null}
+                    onChange={f => setUiFont(f?.name || '')}
                 />
             </div>
             <div>

--- a/ytapp/src/features/settings/index.ts
+++ b/ytapp/src/features/settings/index.ts
@@ -11,6 +11,7 @@ export interface Settings {
     captionSize?: number;
     captionColor?: string;
     captionBg?: string;
+    uiFont?: string;
     accentColor?: string;
     watermark?: string;
     watermarkPosition?: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';


### PR DESCRIPTION
## Summary
- allow selecting a UI font in Settings
- store the UI font in app settings
- apply chosen UI font on app load
- add `ui_font` translation string

## Testing
- `cd ytapp && npm install`
- `cd src-tauri && cargo check`
- `cd .. && npx ts-node src/cli.ts --help`


------
https://chatgpt.com/codex/tasks/task_e_68530d22aaf48331aa5d3096220313b0