### PR TITLE
Update packaging docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -216,7 +216,13 @@ If `cargo check` fails on Linux, run `scripts/install_tauri_deps.sh`.
 * Checks for FFmpeg and the Whisper model at startup. Missing dependencies
   trigger a dialog explaining how to install them.
 * Optional auto-update check notifies users when a new version is available using the Tauri updater plugin.
+* Install the Tauri CLI first: `cargo install tauri-cli`
 * `scripts/package.sh` builds installers for Windows, macOS and Linux
+
+```bash
+cargo install tauri-cli
+./scripts/package.sh
+```
 
 ---
 


### PR DESCRIPTION
## Summary
- note to install Tauri CLI first when packaging

## Testing
- `cd ytapp && npm install`
- `cd src-tauri && cargo check`
- `cd .. && npx ts-node src/cli.ts --help`


------
https://chatgpt.com/codex/tasks/task_e_68531bf8ded883319cd845b0eae3a223