### PR TITLE
Document ts-node prerequisite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,9 @@ cd src-tauri && cargo check
 cd .. && npx ts-node src/cli.ts --help
 ```
 
+Install `ts-node` globally with `npm install -g ts-node` or ensure `npx` can
+download it to run the CLI checks and examples.
+
 `cargo check` may require system packages. Run the appropriate install script
 for your OS (`./scripts/install_tauri_deps.sh`, `./scripts/install_tauri_deps_macos.sh` or `./scripts/install_tauri_deps_windows.ps1`) if needed.
 Be sure `.env.tauri` from `scripts/setup_codex.sh` is sourced (or export the

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 .PHONY: dev test package verify lint ts rust cli
 
+# Use globally installed ts-node if available, otherwise fallback to npx.
+TS_NODE := $(shell command -v ts-node >/dev/null 2>&1 && echo ts-node || echo npx ts-node)
+
 verify: lint ts rust cli
 	@echo "✅  All dev checks passed"
 
@@ -13,19 +16,19 @@ rust:
 	cd ytapp/src-tauri && cargo check --quiet
 
 cli:
-	cd ytapp && npx ts-node src/cli.ts --help >/dev/null
+    cd ytapp && $(TS_NODE) src/cli.ts --help >/dev/null
 
 dev:
 	@echo "Running development checks"
-	npx ts-node scripts/generate-schema.ts
+    $(TS_NODE) scripts/generate-schema.ts
 	cd ytapp && npm install
-	cd ytapp/src-tauri && cargo check
-	cd ../.. && npx ts-node ytapp/src/cli.ts --help
+    cd ytapp/src-tauri && cargo check
+    cd ../.. && $(TS_NODE) ytapp/src/cli.ts --help
 
 test:
-	npx ts-node scripts/generate-schema.ts
-	cd ytapp && npx tsc --noEmit
-	for f in ytapp/tests/*.ts; do npx ts-node "$f" || true; done
+    $(TS_NODE) scripts/generate-schema.ts
+    cd ytapp && npx tsc --noEmit
+    for f in ytapp/tests/*.ts; do $(TS_NODE) "$f" || true; done
 	cd ytapp/src-tauri && cargo test --all-targets || true
 
 package:

--- a/readme.md
+++ b/readme.md
@@ -325,6 +325,10 @@ passed to FFmpeg so subtitles render with your custom font.
 
 ### CLI Usage
 
+All CLI commands use `ts-node`. If you do not have it installed globally run
+`npm install -g ts-node` or prefix the commands with `npx` (requires internet
+access).
+
 Verify dependencies:
 ```bash
 npx ts-node src/cli.ts check-deps


### PR DESCRIPTION
## Summary
- document global `ts-node` requirement in README and AGENTS
- make `make` scripts fall back to `npx ts-node`

## Testing
- `cd ytapp && npm install`
- `cd src-tauri && cargo check`
- `cd ytapp && npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_68531e2069388331afd2e1c333079bdf