### PR TITLE
Add CLI list-fonts command

### DIFF
--- a/ytapp/src/cli.ts
+++ b/ytapp/src/cli.ts
@@ -13,6 +13,7 @@ import { watchDirectory } from './features/watch';
 import { generateBatchWithProgress } from './features/batch';
 import { addJob, listJobs, runQueue, clearQueue, clearCompleted, removeJob, pauseQueue, resumeQueue } from './features/queue';
 import { listProfiles, getProfile, saveProfile, deleteProfile } from './features/profiles';
+import { listFonts } from './features/fonts';
 import type { Profile } from './schema';
 import { verifyDependencies } from './features/dependencies';
 import { getLogs } from './features/logs';
@@ -214,6 +215,19 @@ program
       console.log('All dependencies present');
     } catch (err) {
       console.error('Dependency check failed:', err);
+      process.exitCode = 1;
+    }
+  });
+
+program
+  .command('list-fonts')
+  .description('List detected system fonts')
+  .action(async () => {
+    try {
+      const fonts = await listFonts();
+      fonts.forEach(f => console.log(`${f.name} (${f.style}) - ${f.path}`));
+    } catch (err) {
+      console.error('Error listing fonts:', err);
       process.exitCode = 1;
     }
   });

--- a/ytapp/src/features/fonts.ts
+++ b/ytapp/src/features/fonts.ts
@@ -1,0 +1,14 @@
+export interface SystemFont {
+  name: string;
+  style: string;
+  path: string;
+}
+
+import { invoke } from '@tauri-apps/api/core';
+
+/**
+ * Retrieve available system fonts detected by the backend.
+ */
+export async function listFonts(): Promise<SystemFont[]> {
+  return await invoke('list_fonts');
+}

--- a/ytapp/tests/cli_list_fonts.test.ts
+++ b/ytapp/tests/cli_list_fonts.test.ts
@@ -1,0 +1,17 @@
+import assert from 'assert';
+const core = require('@tauri-apps/api/core');
+const events = require('@tauri-apps/api/event');
+
+(async () => {
+  core.invoke = async (cmd: string) => {
+    assert.strictEqual(cmd, 'list_fonts');
+    return [{ name: 'Arial', style: 'Regular', path: '/fonts/arial.ttf' }];
+  };
+  events.listen = async () => () => {};
+  const logs: string[] = [];
+  console.log = (msg: string) => { logs.push(msg); };
+  process.argv = ['node', 'cli.ts', 'list-fonts'];
+  await import('../src/cli');
+  assert.ok(logs.some(l => l.includes('Arial')));
+  console.log('cli list-fonts test passed');
+})();


### PR DESCRIPTION
## Summary
- expose a new `list-fonts` command in the CLI
- add a small wrapper under `features/fonts`
- test the new command

## Testing
- `npm install`
- `cargo check` in `ytapp/src-tauri`
- `npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_6854aeb2039c8331950cb29a6a1d08d6