### PR TITLE
Add CLI command to list YouTube playlists

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -346,6 +346,18 @@ Sign out again:
 npx ts-node src/cli.ts sign-out
 ```
 
+List available fonts:
+
+```bash
+npx ts-node src/cli.ts list-fonts
+```
+
+List YouTube playlists:
+
+```bash
+npx ts-node src/cli.ts list-playlists
+```
+
 Generate and schedule an upload:
 
 ```bash

--- a/ytapp/src/cli.ts
+++ b/ytapp/src/cli.ts
@@ -14,6 +14,7 @@ import { generateBatchWithProgress } from './features/batch';
 import { addJob, listJobs, runQueue, clearQueue, clearCompleted, removeJob, pauseQueue, resumeQueue } from './features/queue';
 import { listProfiles, getProfile, saveProfile, deleteProfile } from './features/profiles';
 import { listFonts } from './features/fonts';
+import { fetchPlaylists } from './features/youtube';
 import type { Profile } from './schema';
 import { verifyDependencies } from './features/dependencies';
 import { getLogs } from './features/logs';
@@ -228,6 +229,19 @@ program
       fonts.forEach(f => console.log(`${f.name} (${f.style}) - ${f.path}`));
     } catch (err) {
       console.error('Error listing fonts:', err);
+      process.exitCode = 1;
+    }
+  });
+
+program
+  .command('list-playlists')
+  .description('List YouTube playlists')
+  .action(async () => {
+    try {
+      const playlists = await fetchPlaylists();
+      playlists.forEach(p => console.log(`${p.id} - ${p.title}`));
+    } catch (err) {
+      console.error('Error listing playlists:', err);
       process.exitCode = 1;
     }
   });

--- a/ytapp/tests/cli_list_playlists.test.ts
+++ b/ytapp/tests/cli_list_playlists.test.ts
@@ -1,0 +1,17 @@
+import assert from 'assert';
+const core = require('@tauri-apps/api/core');
+const events = require('@tauri-apps/api/event');
+
+(async () => {
+  core.invoke = async (cmd: string) => {
+    assert.strictEqual(cmd, 'list_playlists');
+    return [{ id: 'p1', title: 'Playlist One' }];
+  };
+  events.listen = async () => () => {};
+  const logs: string[] = [];
+  console.log = (msg: string) => { logs.push(msg); };
+  process.argv = ['node', 'cli.ts', 'list-playlists'];
+  await import('../src/cli');
+  assert.ok(logs.some(l => l.includes('Playlist One')));
+  console.log('cli list-playlists test passed');
+})();


### PR DESCRIPTION
## Summary
- add `list-playlists` command to the CLI
- document new command in README
- add test for playlist listing

## Testing
- `cd ytapp && npm install`
- `cd src-tauri && cargo check`
- `cd .. && npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_6854b0e7f67c833184f970a7f3179a6e