### PR TITLE
Add list-languages CLI command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -357,6 +357,10 @@ List YouTube playlists:
 ```bash
 npx ts-node src/cli.ts list-playlists
 ```
+List available languages:
+```bash
+npx ts-node src/cli.ts list-languages
+```
 
 Generate and schedule an upload:
 

--- a/ytapp/src/cli.ts
+++ b/ytapp/src/cli.ts
@@ -247,6 +247,25 @@ program
   });
 
 program
+  .command('list-languages')
+  .description('List available transcription languages')
+  .action(async () => {
+    const dir = path.join(__dirname, 'features/languages/defs');
+    try {
+      const files = await fs.readdir(dir);
+      const defs = await Promise.all(files.map(async f => {
+        const data = await fs.readFile(path.join(dir, f), 'utf-8');
+        return JSON.parse(data) as { value: string; label: string };
+      }));
+      defs.sort((a, b) => a.label.localeCompare(b.label));
+      defs.forEach(l => console.log(`${l.value} - ${l.label}`));
+    } catch (err) {
+      console.error('Error listing languages:', err);
+      process.exitCode = 1;
+    }
+  });
+
+program
   .command('generate')
   .description('Generate video from audio')
   .argument('<file>', 'audio file path')

--- a/ytapp/tests/cli_list_languages.test.ts
+++ b/ytapp/tests/cli_list_languages.test.ts
@@ -1,0 +1,13 @@
+import assert from 'assert';
+const core = require('@tauri-apps/api/core');
+const events = require('@tauri-apps/api/event');
+
+(async () => {
+  events.listen = async () => () => {};
+  const logs: string[] = [];
+  console.log = (msg: string) => { logs.push(msg); };
+  process.argv = ['node', 'cli.ts', 'list-languages'];
+  await import('../src/cli');
+  assert.ok(logs.some(l => l.includes('en')));
+  console.log('cli list-languages test passed');
+})();


### PR DESCRIPTION
## Summary
- implement `list-languages` command in CLI
- document new command in README
- add unit test covering the command

## Testing
- `make verify`

------
https://chatgpt.com/codex/tasks/task_e_6854bbd726588331bab452500a792fa3