### PR TITLE
Add queue-move CLI command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -416,6 +416,10 @@ Remove a job by its index:
 ```bash
 npx ts-node src/cli.ts queue-remove 0
 ```
+Move a job within the queue:
+```bash
+npx ts-node src/cli.ts queue-move 2 0
+```
 Each job now tracks a `status` and `retries` count in `queue.json`.
 Failed jobs remain in the queue until they succeed or exceed the retry limit.
 

--- a/ytapp/src/cli.ts
+++ b/ytapp/src/cli.ts
@@ -11,7 +11,7 @@ import { translateSrt } from './utils/translate';
 import { parseCsv, CsvRow } from './utils/csv';
 import { watchDirectory } from './features/watch';
 import { generateBatchWithProgress } from './features/batch';
-import { addJob, listJobs, runQueue, clearQueue, clearCompleted, removeJob, pauseQueue, resumeQueue } from './features/queue';
+import { addJob, listJobs, runQueue, clearQueue, clearCompleted, removeJob, moveJob, pauseQueue, resumeQueue } from './features/queue';
 import { listProfiles, getProfile, saveProfile, deleteProfile } from './features/profiles';
 import { listFonts } from './features/fonts';
 import { fetchPlaylists } from './features/youtube';
@@ -999,6 +999,20 @@ program
       await removeJob(parseInt(index, 10));
     } catch (err) {
       console.error('Error removing job:', err);
+      process.exitCode = 1;
+    }
+  });
+
+program
+  .command('queue-move')
+  .description('Move a job to a new position')
+  .argument('<from>', 'current index')
+  .argument('<to>', 'destination index')
+  .action(async (from: string, to: string) => {
+    try {
+      await moveJob(parseInt(from, 10), parseInt(to, 10));
+    } catch (err) {
+      console.error('Error moving job:', err);
       process.exitCode = 1;
     }
   });

--- a/ytapp/tests/cli_queue_move.test.ts
+++ b/ytapp/tests/cli_queue_move.test.ts
@@ -1,0 +1,16 @@
+import assert from 'assert';
+const core = require('@tauri-apps/api/core');
+const events = require('@tauri-apps/api/event');
+
+(async () => {
+  let called = '';
+  let args: any;
+  core.invoke = async (cmd: string, a: any) => { called = cmd; args = a; };
+  events.listen = async () => () => {};
+  process.argv = ['node', 'cli.ts', 'queue-move', '2', '0'];
+  await import('../src/cli');
+  assert.strictEqual(called, 'queue_move');
+  assert.strictEqual(args.from, 2);
+  assert.strictEqual(args.to, 0);
+  console.log('cli queue-move test passed');
+})();


### PR DESCRIPTION
## Summary
- support moving jobs in queue via new `queue-move` command
- document the command in README
- test the new command

## Testing
- `npm install`
- `cargo check`
- `npx ts-node src/cli.ts --help`


------
https://chatgpt.com/codex/tasks/task_e_6854c1ebd2508331931650515ed74cab