### PR TITLE
Add CLI sign-in test

### DIFF
--- a/ytapp/tests/cli_signin.test.ts
+++ b/ytapp/tests/cli_signin.test.ts
@@ -1,0 +1,19 @@
+import assert from 'assert';
+const core = require('@tauri-apps/api/core');
+const events = require('@tauri-apps/api/event');
+
+(async () => {
+  let invoked = false;
+  core.invoke = async (cmd: string) => {
+    assert.strictEqual(cmd, 'youtube_sign_in');
+    invoked = true;
+  };
+  events.listen = async () => () => {};
+  const logs: string[] = [];
+  console.log = (msg: string) => { logs.push(msg); };
+  process.argv = ['node', 'cli.ts', 'sign-in'];
+  await import('../src/cli');
+  assert.ok(invoked);
+  assert.ok(logs.some(l => l.includes('Sign-in complete')));
+  console.log('cli sign-in test passed');
+})();


### PR DESCRIPTION
## Summary
- test CLI `sign-in` command

## Testing
- `npm install`
- `cargo check`
- `npx ts-node src/cli.ts --help`


------
https://chatgpt.com/codex/tasks/task_e_6854c85017ac8331a6a34f353c56cb49