### PR TITLE
Add CLI sign-out test

### DIFF
--- a/ytapp/tests/cli_signout.test.ts
+++ b/ytapp/tests/cli_signout.test.ts
@@ -1,0 +1,19 @@
+import assert from 'assert';
+const core = require('@tauri-apps/api/core');
+const events = require('@tauri-apps/api/event');
+
+(async () => {
+  let invoked = false;
+  core.invoke = async (cmd: string) => {
+    assert.strictEqual(cmd, 'youtube_sign_out');
+    invoked = true;
+  };
+  events.listen = async () => () => {};
+  const logs: string[] = [];
+  console.log = (msg: string) => { logs.push(msg); };
+  process.argv = ['node', 'cli.ts', 'sign-out'];
+  await import('../src/cli');
+  assert.ok(invoked);
+  assert.ok(logs.some(l => l.includes('Signed out')));
+  console.log('cli sign-out test passed');
+})();


### PR DESCRIPTION
## Summary
- add missing CLI test for `sign-out`

## Testing
- `cd ytapp && npm install`
- `cd src-tauri && cargo check`
- `cd .. && npx ts-node src/cli.ts --help`


------
https://chatgpt.com/codex/tasks/task_e_6854cef27fb48331adaa32192deeb0ed