### PR TITLE
Add CLI sign-in status command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -346,6 +346,12 @@ Sign out again:
 npx ts-node src/cli.ts sign-out
 ```
 
+Check if you are signed in:
+
+```bash
+npx ts-node src/cli.ts is-signed-in
+```
+
 List available fonts:
 
 ```bash

--- a/ytapp/src/cli.ts
+++ b/ytapp/src/cli.ts
@@ -202,6 +202,13 @@ async function signOut(): Promise<void> {
   await invoke('youtube_sign_out');
 }
 
+/**
+ * Check whether a valid YouTube session exists.
+ */
+async function isSignedIn(): Promise<boolean> {
+  return await invoke('youtube_is_signed_in');
+}
+
 program
   .name('ytcli')
   .description('CLI for generating and uploading videos. Press Ctrl+C to cancel operations.')
@@ -863,6 +870,19 @@ program
       console.log('Signed out');
     } catch (err) {
       console.error('Error during sign-out:', err);
+      process.exitCode = 1;
+    }
+  });
+
+program
+  .command('is-signed-in')
+  .description('Check whether YouTube credentials are present')
+  .action(async () => {
+    try {
+      const ok = await isSignedIn();
+      console.log(ok ? 'Signed in' : 'Not signed in');
+    } catch (err) {
+      console.error('Error checking sign-in:', err);
       process.exitCode = 1;
     }
   });

--- a/ytapp/tests/cli_is_signed_in_false.test.ts
+++ b/ytapp/tests/cli_is_signed_in_false.test.ts
@@ -1,0 +1,20 @@
+import assert from 'assert';
+const core = require('@tauri-apps/api/core');
+const events = require('@tauri-apps/api/event');
+
+(async () => {
+  let called = false;
+  core.invoke = async (cmd: string) => {
+    called = true;
+    assert.strictEqual(cmd, 'youtube_is_signed_in');
+    return false;
+  };
+  events.listen = async () => () => {};
+  const logs: string[] = [];
+  console.log = (msg: string) => { logs.push(msg); };
+  process.argv = ['node', 'cli.ts', 'is-signed-in'];
+  await import('../src/cli');
+  assert.ok(called);
+  assert.ok(logs.some(l => l.includes('Not signed in')));
+  console.log('cli is-signed-in false test passed');
+})();

--- a/ytapp/tests/cli_is_signed_in_true.test.ts
+++ b/ytapp/tests/cli_is_signed_in_true.test.ts
@@ -1,0 +1,20 @@
+import assert from 'assert';
+const core = require('@tauri-apps/api/core');
+const events = require('@tauri-apps/api/event');
+
+(async () => {
+  let called = false;
+  core.invoke = async (cmd: string) => {
+    called = true;
+    assert.strictEqual(cmd, 'youtube_is_signed_in');
+    return true;
+  };
+  events.listen = async () => () => {};
+  const logs: string[] = [];
+  console.log = (msg: string) => { logs.push(msg); };
+  process.argv = ['node', 'cli.ts', 'is-signed-in'];
+  await import('../src/cli');
+  assert.ok(called);
+  assert.ok(logs.some(l => l.includes('Signed in')));
+  console.log('cli is-signed-in true test passed');
+})();


### PR DESCRIPTION
## Summary
- expose `is-signed-in` command in CLI
- document the command in README
- implement `isSignedIn` helper and tests for both states

## Testing
- `npm install`
- `cargo check`
- `npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_6854d69af30c833193998048e3ebab4e