### PR TITLE
Add queue failed cleanup command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -432,6 +432,10 @@ Remove only completed or failed jobs:
 ```bash
 npx ts-node src/cli.ts queue-clear-completed
 ```
+Remove only failed jobs:
+```bash
+npx ts-node src/cli.ts queue-clear-failed
+```
 
 Process all queued jobs (retry failed jobs with `--retry-failed`):
 

--- a/ytapp/src-tauri/src/main.rs
+++ b/ytapp/src-tauri/src/main.rs
@@ -1014,6 +1014,13 @@ fn queue_clear_completed(app: tauri::AppHandle) -> Result<(), String> {
 }
 
 #[command]
+fn queue_clear_failed(app: tauri::AppHandle) -> Result<(), String> {
+    load_queue(&app).ok();
+    log(&app, "info", "queue_clear_failed");
+    job_queue::clear_failed(&app)
+}
+
+#[command]
 fn queue_pause(_app: tauri::AppHandle) {
     job_queue::set_paused(true);
     job_queue::notifier().notify_one();
@@ -1351,7 +1358,7 @@ fn main() {
             }
             Ok(())
         })
-        .invoke_handler(tauri::generate_handler![generate_video, upload_video, upload_videos, transcribe_audio, generate_upload, generate_batch_upload, watch_directory, youtube_sign_in, youtube_sign_out, youtube_is_signed_in, list_playlists, load_settings, save_settings, load_srt, save_srt, cancel_generate, cancel_upload, queue_add, queue_list, queue_remove, queue_move, queue_clear, queue_clear_completed, queue_pause, queue_resume, queue_process, profile_list, profile_get, profile_save, profile_delete, verify_dependencies, install_tauri_deps, list_fonts, get_logs])
+        .invoke_handler(tauri::generate_handler![generate_video, upload_video, upload_videos, transcribe_audio, generate_upload, generate_batch_upload, watch_directory, youtube_sign_in, youtube_sign_out, youtube_is_signed_in, list_playlists, load_settings, save_settings, load_srt, save_srt, cancel_generate, cancel_upload, queue_add, queue_list, queue_remove, queue_move, queue_clear, queue_clear_completed, queue_clear_failed, queue_pause, queue_resume, queue_process, profile_list, profile_get, profile_save, profile_delete, verify_dependencies, install_tauri_deps, list_fonts, get_logs])
         .run(context)
         .expect("error while running tauri application");
 }

--- a/ytapp/src/cli.ts
+++ b/ytapp/src/cli.ts
@@ -11,7 +11,7 @@ import { translateSrt } from './utils/translate';
 import { parseCsv, CsvRow } from './utils/csv';
 import { watchDirectory } from './features/watch';
 import { generateBatchWithProgress } from './features/batch';
-import { addJob, listJobs, runQueue, clearQueue, clearCompleted, removeJob, moveJob, pauseQueue, resumeQueue } from './features/queue';
+import { addJob, listJobs, runQueue, clearQueue, clearCompleted, clearFailed, removeJob, moveJob, pauseQueue, resumeQueue } from './features/queue';
 import { listProfiles, getProfile, saveProfile, deleteProfile } from './features/profiles';
 import { listFonts } from './features/fonts';
 import { fetchPlaylists } from './features/youtube';
@@ -1025,6 +1025,18 @@ program
       await clearQueue();
     } catch (err) {
       console.error('Error clearing queue:', err);
+      process.exitCode = 1;
+    }
+  });
+
+program
+  .command('queue-clear-failed')
+  .description('Remove failed jobs from the queue')
+  .action(async () => {
+    try {
+      await clearFailed();
+    } catch (err) {
+      console.error('Error clearing failed jobs:', err);
       process.exitCode = 1;
     }
   });

--- a/ytapp/src/features/queue.ts
+++ b/ytapp/src/features/queue.ts
@@ -41,6 +41,11 @@ export async function clearCompleted(): Promise<void> {
   await invoke('queue_clear_completed');
 }
 
+/** Remove failed jobs from the queue. */
+export async function clearFailed(): Promise<void> {
+  await invoke('queue_clear_failed');
+}
+
 export async function runQueue(retryFailed = false): Promise<void> {
   await invoke('queue_process', { retryFailed });
 }

--- a/ytapp/tests/cli_queue_clear_failed.test.ts
+++ b/ytapp/tests/cli_queue_clear_failed.test.ts
@@ -1,0 +1,13 @@
+import assert from 'assert';
+const core = require('@tauri-apps/api/core');
+const events = require('@tauri-apps/api/event');
+
+(async () => {
+  let called = '';
+  core.invoke = async (cmd: string) => { called = cmd; };
+  events.listen = async () => () => {};
+  process.argv = ['node', 'cli.ts', 'queue-clear-failed'];
+  await import('../src/cli');
+  assert.strictEqual(called, 'queue_clear_failed');
+  console.log('cli queue-clear-failed test passed');
+})();

--- a/ytapp/tests/queue_clear_failed.test.ts
+++ b/ytapp/tests/queue_clear_failed.test.ts
@@ -1,0 +1,20 @@
+import assert from 'assert';
+const core = require('@tauri-apps/api/core');
+
+(async () => {
+  let q: any[] = [
+    { job: { Generate: { params: { file: 'a.mp3' }, dest: 'a.mp4' } }, status: 'failed', retries: 1 },
+    { job: { Generate: { params: { file: 'b.mp3' }, dest: 'b.mp4' } }, status: 'pending', retries: 0 }
+  ];
+  core.invoke = async (cmd: string) => {
+    if (cmd === 'queue_clear_failed') { q = q.filter(i => i.status !== 'failed'); return; }
+    if (cmd === 'queue_list') { return q; }
+  };
+  const { clearFailed, listJobs } = await import('../src/features/queue');
+  await clearFailed();
+  const jobs = await listJobs();
+  assert.strictEqual(jobs.length, 1);
+  const dest = (jobs[0].job as any).Generate.dest;
+  assert.strictEqual(dest, 'b.mp4');
+  console.log('queue clearFailed tests passed');
+})();


### PR DESCRIPTION
## Summary
- implement `clear_failed` in Rust job queue logic
- expose as `queue_clear_failed` Tauri command
- provide TS wrapper and CLI command
- update README docs
- add unit tests for new behavior

## Testing
- `npm install`
- `cargo check`
- `npx ts-node src/cli.ts --help`
- `npx ts-node tests/queue_clear_failed.test.ts`
- `npx ts-node tests/cli_queue_clear_failed.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_685808cbb2208331ba8b9cd83208c139