### PR TITLE
Clarify queue clearing text

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -40,7 +40,7 @@ This project follows a minimalist approach inspired by the principle **"Less but
 - Typography scales in small increments (1.25x) for harmony.
 - The Font selector includes a search field to quickly filter large font lists.
 - The Playlist picker lets users choose from existing YouTube playlists instead of typing IDs.
-- The Queue status panel offers a **Clear Completed** button to remove finished jobs.
+- The Queue status panel offers a **Clear Completed and Failed** button to remove finished jobs.
 - The onboarding modal uses a simple multi-step wizard with Next/Back controls.
 
 Inspired by the work of Dieter Rams and Jony Ive, these rules emphasize clarity, restrained color use and quiet motion. Always strive for "as little design as possible".

--- a/readme.md
+++ b/readme.md
@@ -428,7 +428,7 @@ Clear the queue:
 ```bash
 npx ts-node src/cli.ts queue-clear
 ```
-Remove only completed or failed jobs:
+Clear completed and failed jobs:
 ```bash
 npx ts-node src/cli.ts queue-clear-completed
 ```

--- a/ytapp/public/locales/af/translation.json
+++ b/ytapp/public/locales/af/translation.json
@@ -16,7 +16,7 @@
   "guide_select_audio": "Select an audio file",
   "guide_generate": "Click Generate to create your video",
   "guide_upload": "Use Generate & Upload to post to YouTube",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/ar/translation.json
+++ b/ytapp/public/locales/ar/translation.json
@@ -55,7 +55,7 @@
   "delete_profile": "Delete Profile",
   "load": "Load",
   "edit": "Edit",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/az/translation.json
+++ b/ytapp/public/locales/az/translation.json
@@ -16,7 +16,7 @@
   "guide_select_audio": "Select an audio file",
   "guide_generate": "Click Generate to create your video",
   "guide_upload": "Use Generate & Upload to post to YouTube",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/be/translation.json
+++ b/ytapp/public/locales/be/translation.json
@@ -16,7 +16,7 @@
   "guide_select_audio": "Select an audio file",
   "guide_generate": "Click Generate to create your video",
   "guide_upload": "Use Generate & Upload to post to YouTube",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/bg/translation.json
+++ b/ytapp/public/locales/bg/translation.json
@@ -55,7 +55,7 @@
   "delete_profile": "Delete Profile",
   "load": "Load",
   "edit": "Edit",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/bn/translation.json
+++ b/ytapp/public/locales/bn/translation.json
@@ -16,7 +16,7 @@
   "guide_select_audio": "Select an audio file",
   "guide_generate": "Click Generate to create your video",
   "guide_upload": "Use Generate & Upload to post to YouTube",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/bs/translation.json
+++ b/ytapp/public/locales/bs/translation.json
@@ -16,7 +16,7 @@
   "guide_select_audio": "Select an audio file",
   "guide_generate": "Click Generate to create your video",
   "guide_upload": "Use Generate & Upload to post to YouTube",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/ca/translation.json
+++ b/ytapp/public/locales/ca/translation.json
@@ -16,7 +16,7 @@
   "guide_select_audio": "Select an audio file",
   "guide_generate": "Click Generate to create your video",
   "guide_upload": "Use Generate & Upload to post to YouTube",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/cs/translation.json
+++ b/ytapp/public/locales/cs/translation.json
@@ -55,7 +55,7 @@
   "delete_profile": "Delete Profile",
   "load": "Load",
   "edit": "Edit",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/cy/translation.json
+++ b/ytapp/public/locales/cy/translation.json
@@ -16,7 +16,7 @@
   "guide_select_audio": "Select an audio file",
   "guide_generate": "Click Generate to create your video",
   "guide_upload": "Use Generate & Upload to post to YouTube",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/da/translation.json
+++ b/ytapp/public/locales/da/translation.json
@@ -55,7 +55,7 @@
   "delete_profile": "Delete Profile",
   "load": "Load",
   "edit": "Edit",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/de/translation.json
+++ b/ytapp/public/locales/de/translation.json
@@ -51,7 +51,7 @@
   "guide_select_audio": "Select an audio file",
   "guide_generate": "Click Generate to create your video",
   "guide_upload": "Use Generate & Upload to post to YouTube",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/el/translation.json
+++ b/ytapp/public/locales/el/translation.json
@@ -55,7 +55,7 @@
   "delete_profile": "Delete Profile",
   "load": "Load",
   "edit": "Edit",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/en/translation.json
+++ b/ytapp/public/locales/en/translation.json
@@ -74,7 +74,7 @@
   "delete_profile": "Delete Profile",
   "load": "Load",
   "edit": "Edit",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "remove": "Remove",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",

--- a/ytapp/public/locales/es/translation.json
+++ b/ytapp/public/locales/es/translation.json
@@ -55,7 +55,7 @@
   "delete_profile": "Delete Profile",
   "load": "Load",
   "edit": "Edit",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/et/translation.json
+++ b/ytapp/public/locales/et/translation.json
@@ -16,7 +16,7 @@
   "guide_select_audio": "Select an audio file",
   "guide_generate": "Click Generate to create your video",
   "guide_upload": "Use Generate & Upload to post to YouTube",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/eu/translation.json
+++ b/ytapp/public/locales/eu/translation.json
@@ -16,7 +16,7 @@
   "guide_select_audio": "Select an audio file",
   "guide_generate": "Click Generate to create your video",
   "guide_upload": "Use Generate & Upload to post to YouTube",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/fa/translation.json
+++ b/ytapp/public/locales/fa/translation.json
@@ -16,7 +16,7 @@
   "guide_select_audio": "Select an audio file",
   "guide_generate": "Click Generate to create your video",
   "guide_upload": "Use Generate & Upload to post to YouTube",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/fi/translation.json
+++ b/ytapp/public/locales/fi/translation.json
@@ -55,7 +55,7 @@
   "delete_profile": "Delete Profile",
   "load": "Load",
   "edit": "Edit",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/fr/translation.json
+++ b/ytapp/public/locales/fr/translation.json
@@ -55,7 +55,7 @@
   "delete_profile": "Delete Profile",
   "load": "Load",
   "edit": "Edit",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/gl/translation.json
+++ b/ytapp/public/locales/gl/translation.json
@@ -16,7 +16,7 @@
   "guide_select_audio": "Select an audio file",
   "guide_generate": "Click Generate to create your video",
   "guide_upload": "Use Generate & Upload to post to YouTube",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/gu/translation.json
+++ b/ytapp/public/locales/gu/translation.json
@@ -16,7 +16,7 @@
   "guide_select_audio": "Select an audio file",
   "guide_generate": "Click Generate to create your video",
   "guide_upload": "Use Generate & Upload to post to YouTube",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/he/translation.json
+++ b/ytapp/public/locales/he/translation.json
@@ -55,7 +55,7 @@
   "delete_profile": "Delete Profile",
   "load": "Load",
   "edit": "Edit",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/hi/translation.json
+++ b/ytapp/public/locales/hi/translation.json
@@ -55,7 +55,7 @@
   "delete_profile": "Delete Profile",
   "load": "Load",
   "edit": "Edit",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/hr/translation.json
+++ b/ytapp/public/locales/hr/translation.json
@@ -55,7 +55,7 @@
   "delete_profile": "Delete Profile",
   "load": "Load",
   "edit": "Edit",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/hu/translation.json
+++ b/ytapp/public/locales/hu/translation.json
@@ -55,7 +55,7 @@
   "delete_profile": "Delete Profile",
   "load": "Load",
   "edit": "Edit",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/hy/translation.json
+++ b/ytapp/public/locales/hy/translation.json
@@ -16,7 +16,7 @@
   "guide_select_audio": "Select an audio file",
   "guide_generate": "Click Generate to create your video",
   "guide_upload": "Use Generate & Upload to post to YouTube",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/id/translation.json
+++ b/ytapp/public/locales/id/translation.json
@@ -55,7 +55,7 @@
   "delete_profile": "Delete Profile",
   "load": "Load",
   "edit": "Edit",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/is/translation.json
+++ b/ytapp/public/locales/is/translation.json
@@ -16,7 +16,7 @@
   "guide_select_audio": "Select an audio file",
   "guide_generate": "Click Generate to create your video",
   "guide_upload": "Use Generate & Upload to post to YouTube",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/it/translation.json
+++ b/ytapp/public/locales/it/translation.json
@@ -55,7 +55,7 @@
   "delete_profile": "Delete Profile",
   "load": "Load",
   "edit": "Edit",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/ja/translation.json
+++ b/ytapp/public/locales/ja/translation.json
@@ -51,7 +51,7 @@
   "guide_select_audio": "Select an audio file",
   "guide_generate": "Click Generate to create your video",
   "guide_upload": "Use Generate & Upload to post to YouTube",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/kk/translation.json
+++ b/ytapp/public/locales/kk/translation.json
@@ -16,7 +16,7 @@
   "guide_select_audio": "Select an audio file",
   "guide_generate": "Click Generate to create your video",
   "guide_upload": "Use Generate & Upload to post to YouTube",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/kn/translation.json
+++ b/ytapp/public/locales/kn/translation.json
@@ -16,7 +16,7 @@
   "guide_select_audio": "Select an audio file",
   "guide_generate": "Click Generate to create your video",
   "guide_upload": "Use Generate & Upload to post to YouTube",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/ko/translation.json
+++ b/ytapp/public/locales/ko/translation.json
@@ -55,7 +55,7 @@
   "delete_profile": "Delete Profile",
   "load": "Load",
   "edit": "Edit",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/lt/translation.json
+++ b/ytapp/public/locales/lt/translation.json
@@ -55,7 +55,7 @@
   "delete_profile": "Delete Profile",
   "load": "Load",
   "edit": "Edit",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/lv/translation.json
+++ b/ytapp/public/locales/lv/translation.json
@@ -55,7 +55,7 @@
   "delete_profile": "Delete Profile",
   "load": "Load",
   "edit": "Edit",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/mi/translation.json
+++ b/ytapp/public/locales/mi/translation.json
@@ -16,7 +16,7 @@
   "guide_select_audio": "Select an audio file",
   "guide_generate": "Click Generate to create your video",
   "guide_upload": "Use Generate & Upload to post to YouTube",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/mk/translation.json
+++ b/ytapp/public/locales/mk/translation.json
@@ -16,7 +16,7 @@
   "guide_select_audio": "Select an audio file",
   "guide_generate": "Click Generate to create your video",
   "guide_upload": "Use Generate & Upload to post to YouTube",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/mr/translation.json
+++ b/ytapp/public/locales/mr/translation.json
@@ -16,7 +16,7 @@
   "guide_select_audio": "Select an audio file",
   "guide_generate": "Click Generate to create your video",
   "guide_upload": "Use Generate & Upload to post to YouTube",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/ms/translation.json
+++ b/ytapp/public/locales/ms/translation.json
@@ -55,7 +55,7 @@
   "delete_profile": "Delete Profile",
   "load": "Load",
   "edit": "Edit",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/ne/translation.json
+++ b/ytapp/public/locales/ne/translation.json
@@ -55,7 +55,7 @@
   "delete_profile": "Delete Profile",
   "load": "Load",
   "edit": "Edit",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/nl/translation.json
+++ b/ytapp/public/locales/nl/translation.json
@@ -55,7 +55,7 @@
   "delete_profile": "Delete Profile",
   "load": "Load",
   "edit": "Edit",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/nn/translation.json
+++ b/ytapp/public/locales/nn/translation.json
@@ -16,7 +16,7 @@
   "guide_select_audio": "Select an audio file",
   "guide_generate": "Click Generate to create your video",
   "guide_upload": "Use Generate & Upload to post to YouTube",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/no/translation.json
+++ b/ytapp/public/locales/no/translation.json
@@ -55,7 +55,7 @@
   "delete_profile": "Delete Profile",
   "load": "Load",
   "edit": "Edit",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/pa/translation.json
+++ b/ytapp/public/locales/pa/translation.json
@@ -16,7 +16,7 @@
   "guide_select_audio": "Select an audio file",
   "guide_generate": "Click Generate to create your video",
   "guide_upload": "Use Generate & Upload to post to YouTube",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/pl/translation.json
+++ b/ytapp/public/locales/pl/translation.json
@@ -55,7 +55,7 @@
   "delete_profile": "Delete Profile",
   "load": "Load",
   "edit": "Edit",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/pt/translation.json
+++ b/ytapp/public/locales/pt/translation.json
@@ -51,7 +51,7 @@
   "guide_select_audio": "Select an audio file",
   "guide_generate": "Click Generate to create your video",
   "guide_upload": "Use Generate & Upload to post to YouTube",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/ro/translation.json
+++ b/ytapp/public/locales/ro/translation.json
@@ -55,7 +55,7 @@
   "delete_profile": "Delete Profile",
   "load": "Load",
   "edit": "Edit",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/ru/translation.json
+++ b/ytapp/public/locales/ru/translation.json
@@ -51,7 +51,7 @@
   "guide_select_audio": "Select an audio file",
   "guide_generate": "Click Generate to create your video",
   "guide_upload": "Use Generate & Upload to post to YouTube",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/sk/translation.json
+++ b/ytapp/public/locales/sk/translation.json
@@ -55,7 +55,7 @@
   "delete_profile": "Delete Profile",
   "load": "Load",
   "edit": "Edit",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/sl/translation.json
+++ b/ytapp/public/locales/sl/translation.json
@@ -16,7 +16,7 @@
   "guide_select_audio": "Select an audio file",
   "guide_generate": "Click Generate to create your video",
   "guide_upload": "Use Generate & Upload to post to YouTube",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/sq/translation.json
+++ b/ytapp/public/locales/sq/translation.json
@@ -16,7 +16,7 @@
   "guide_select_audio": "Select an audio file",
   "guide_generate": "Click Generate to create your video",
   "guide_upload": "Use Generate & Upload to post to YouTube",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/sr/translation.json
+++ b/ytapp/public/locales/sr/translation.json
@@ -16,7 +16,7 @@
   "guide_select_audio": "Select an audio file",
   "guide_generate": "Click Generate to create your video",
   "guide_upload": "Use Generate & Upload to post to YouTube",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/sv/translation.json
+++ b/ytapp/public/locales/sv/translation.json
@@ -55,7 +55,7 @@
   "delete_profile": "Delete Profile",
   "load": "Load",
   "edit": "Edit",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/sw/translation.json
+++ b/ytapp/public/locales/sw/translation.json
@@ -16,7 +16,7 @@
   "guide_select_audio": "Select an audio file",
   "guide_generate": "Click Generate to create your video",
   "guide_upload": "Use Generate & Upload to post to YouTube",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/ta/translation.json
+++ b/ytapp/public/locales/ta/translation.json
@@ -16,7 +16,7 @@
   "guide_select_audio": "Select an audio file",
   "guide_generate": "Click Generate to create your video",
   "guide_upload": "Use Generate & Upload to post to YouTube",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/te/translation.json
+++ b/ytapp/public/locales/te/translation.json
@@ -16,7 +16,7 @@
   "guide_select_audio": "Select an audio file",
   "guide_generate": "Click Generate to create your video",
   "guide_upload": "Use Generate & Upload to post to YouTube",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/th/translation.json
+++ b/ytapp/public/locales/th/translation.json
@@ -55,7 +55,7 @@
   "delete_profile": "Delete Profile",
   "load": "Load",
   "edit": "Edit",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/tl/translation.json
+++ b/ytapp/public/locales/tl/translation.json
@@ -16,7 +16,7 @@
   "guide_select_audio": "Select an audio file",
   "guide_generate": "Click Generate to create your video",
   "guide_upload": "Use Generate & Upload to post to YouTube",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/tr/translation.json
+++ b/ytapp/public/locales/tr/translation.json
@@ -55,7 +55,7 @@
   "delete_profile": "Delete Profile",
   "load": "Load",
   "edit": "Edit",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/uk/translation.json
+++ b/ytapp/public/locales/uk/translation.json
@@ -55,7 +55,7 @@
   "delete_profile": "Delete Profile",
   "load": "Load",
   "edit": "Edit",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/ur/translation.json
+++ b/ytapp/public/locales/ur/translation.json
@@ -55,7 +55,7 @@
   "delete_profile": "Delete Profile",
   "load": "Load",
   "edit": "Edit",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/vi/translation.json
+++ b/ytapp/public/locales/vi/translation.json
@@ -55,7 +55,7 @@
   "delete_profile": "Delete Profile",
   "load": "Load",
   "edit": "Edit",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/public/locales/zh/translation.json
+++ b/ytapp/public/locales/zh/translation.json
@@ -55,7 +55,7 @@
   "delete_profile": "Delete Profile",
   "load": "Load",
   "edit": "Edit",
-  "clear_completed": "Clear Completed",
+  "clear_completed": "Clear completed and failed jobs.",
   "update_available": "Update Available",
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",

--- a/ytapp/src/cli.ts
+++ b/ytapp/src/cli.ts
@@ -1031,12 +1031,12 @@ program
 
 program
   .command('queue-clear-completed')
-  .description('Remove completed jobs from the queue')
+  .description('Remove completed and failed jobs from the queue')
   .action(async () => {
     try {
       await clearCompleted();
     } catch (err) {
-      console.error('Error clearing completed jobs:', err);
+      console.error('Error clearing completed and failed jobs:', err);
       process.exitCode = 1;
     }
   });


### PR DESCRIPTION
## Summary
- clarify CLI and UI text around clearing jobs
- update translations for `clear_completed`
- adjust design doc and README references

## Testing
- `cd ytapp && npm install`
- `cd src-tauri && cargo check`
- `cd .. && npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_685808c77b708331bb82bf9f5fd90035