### PR TITLE
Implement watch-stop CLI command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -284,6 +284,7 @@ the GTK/WebKit packages and create `.env.tauri`. Then **source `.env.tauri`**
 To automatically process files placed in a folder set the **Watch Directory**
 and enable **Auto Upload** in the settings page or use the CLI `watch` command.
 When the app starts it will immediately begin watching the configured folder using your saved settings.
+Run `npx ts-node src/cli.ts watch-stop` to disable watching again.
 
 ### Contribution
 
@@ -399,6 +400,11 @@ Watch a directory and automatically process new audio files:
 
 ```bash
 npx ts-node src/cli.ts watch ./incoming --auto-upload
+```
+Stop watching:
+
+```bash
+npx ts-node src/cli.ts watch-stop
 ```
 
 Queue up a file for later processing:

--- a/ytapp/src/cli.ts
+++ b/ytapp/src/cli.ts
@@ -978,6 +978,18 @@ program
   });
 
 program
+  .command('watch-stop')
+  .description('Stop watching for new audio files')
+  .action(async () => {
+    try {
+      await watchDirectory('', { autoUpload: false } as any);
+    } catch (err) {
+      console.error('Error stopping watch:', err);
+      process.exitCode = 1;
+    }
+  });
+
+program
   .command('queue-list')
   .description('List pending queue jobs')
   .action(async () => {

--- a/ytapp/tests/watch.test.ts
+++ b/ytapp/tests/watch.test.ts
@@ -30,3 +30,16 @@ const events = require('@tauri-apps/api/event');
   assert.ok(called);
   console.log('watch directory tests passed');
 })();
+
+(async () => {
+  let args: any;
+  core.invoke = async (cmd: string, a: any) => {
+    if (cmd === 'watch_directory') args = a;
+  };
+  events.listen = async () => () => {};
+  process.argv = ['node', 'cli.ts', 'watch-stop'];
+  await import('../src/cli');
+  assert.strictEqual(args.dir, '');
+  assert.strictEqual(args.options.autoUpload, false);
+  console.log('cli watch-stop test passed');
+})();


### PR DESCRIPTION
## Summary
- add `watch-stop` command to disable background watching
- update docs with instructions to stop watching
- test new command in `watch.test.ts`

## Testing
- `npx -y ts-node ytapp/tests/watch.test.ts`
- `npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_685808c283b8833183823d821996b96e