### PR TITLE
Add log clearing command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -200,7 +200,7 @@ If `cargo check` fails on Linux, run `scripts/install_tauri_deps.sh`.
    launch when a matching translation exists. Contributions to improve
    translations are welcome.
 * Video preview modal after generation
-* Logs page to view application logs
+* Logs page to view and clear application logs
 
 ---
 
@@ -464,6 +464,11 @@ View recent logs:
 
 ```bash
 npx ts-node src/cli.ts logs 200
+```
+Clear the log file:
+
+```bash
+npx ts-node src/cli.ts logs-clear
 ```
 The maximum retry count is configurable in the Settings page or by `max_retries` in `settings.json` (default `3`).
 

--- a/ytapp/public/locales/en/translation.json
+++ b/ytapp/public/locales/en/translation.json
@@ -86,6 +86,7 @@
   "logs": "Logs",
   "refresh": "Refresh",
   "save_logs": "Save Logs",
+  "clear_logs": "Clear Logs",
   "help": "Help",
   "pause": "Pause",
   "resume": "Resume",

--- a/ytapp/src-tauri/src/logger.rs
+++ b/ytapp/src-tauri/src/logger.rs
@@ -1,4 +1,4 @@
-use std::fs::{OpenOptions, create_dir_all};
+use std::fs::{OpenOptions, create_dir_all, File};
 use std::io::Write;
 use std::path::PathBuf;
 use tauri::api::path::app_config_dir;
@@ -43,4 +43,9 @@ pub fn read_logs(app: &tauri::AppHandle, max_lines: usize) -> Result<String, Str
     let lines: Vec<&str> = data.lines().collect();
     let start = lines.len().saturating_sub(max_lines);
     Ok(lines[start..].join("\n"))
+}
+
+pub fn clear_logs(app: &tauri::AppHandle) -> Result<(), String> {
+    let path = log_path(app)?;
+    File::create(path).map(|_| ()).map_err(|e| e.to_string())
 }

--- a/ytapp/src-tauri/src/main.rs
+++ b/ytapp/src-tauri/src/main.rs
@@ -30,7 +30,7 @@ use token_store::EncryptedTokenStorage;
 mod job_queue;
 use job_queue::{Job, QueueItem, enqueue, dequeue, peek_all, load_queue, clear_queue as clear_in_memory, notifier, mark_complete, mark_failed};
 mod logger;
-use logger::{log, read_logs};
+use logger::{log, read_logs, clear_logs};
 use tauri::api::dialog::{blocking::MessageDialogBuilder, MessageDialogKind};
 use notify::{RecommendedWatcher, RecursiveMode, Watcher, Config, EventKind, Event, Error as NotifyError};
 use once_cell::sync::Lazy;
@@ -1348,6 +1348,11 @@ fn get_logs(app: tauri::AppHandle, max_lines: Option<usize>) -> Result<String, S
     read_logs(&app, max_lines.unwrap_or(200))
 }
 
+#[command]
+fn clear_logs_cmd(app: tauri::AppHandle) -> Result<(), String> {
+    clear_logs(&app)
+}
+
 fn main() {
     let context = tauri::generate_context!();
     ensure_whisper_model(&context.config());
@@ -1358,7 +1363,7 @@ fn main() {
             }
             Ok(())
         })
-        .invoke_handler(tauri::generate_handler![generate_video, upload_video, upload_videos, transcribe_audio, generate_upload, generate_batch_upload, watch_directory, youtube_sign_in, youtube_sign_out, youtube_is_signed_in, list_playlists, load_settings, save_settings, load_srt, save_srt, cancel_generate, cancel_upload, queue_add, queue_list, queue_remove, queue_move, queue_clear, queue_clear_completed, queue_clear_failed, queue_pause, queue_resume, queue_process, profile_list, profile_get, profile_save, profile_delete, verify_dependencies, install_tauri_deps, list_fonts, get_logs])
+        .invoke_handler(tauri::generate_handler![generate_video, upload_video, upload_videos, transcribe_audio, generate_upload, generate_batch_upload, watch_directory, youtube_sign_in, youtube_sign_out, youtube_is_signed_in, list_playlists, load_settings, save_settings, load_srt, save_srt, cancel_generate, cancel_upload, queue_add, queue_list, queue_remove, queue_move, queue_clear, queue_clear_completed, queue_clear_failed, queue_pause, queue_resume, queue_process, profile_list, profile_get, profile_save, profile_delete, verify_dependencies, install_tauri_deps, list_fonts, get_logs, clear_logs_cmd])
         .run(context)
         .expect("error while running tauri application");
 }

--- a/ytapp/src/cli.ts
+++ b/ytapp/src/cli.ts
@@ -17,7 +17,7 @@ import { listFonts } from './features/fonts';
 import { fetchPlaylists } from './features/youtube';
 import type { Profile } from './schema';
 import { verifyDependencies } from './features/dependencies';
-import { getLogs } from './features/logs';
+import { getLogs, clearLogs } from './features/logs';
 
 async function callWithProgress<T>(
   fn: () => Promise<T>,
@@ -1134,6 +1134,18 @@ program
       console.log(text);
     } catch (err) {
       console.error('Error reading logs:', err);
+      process.exitCode = 1;
+    }
+  });
+
+program
+  .command('logs-clear')
+  .description('Delete the log file')
+  .action(async () => {
+    try {
+      await clearLogs();
+    } catch (err) {
+      console.error('Error clearing logs:', err);
       process.exitCode = 1;
     }
   });

--- a/ytapp/src/components/LogsPage.tsx
+++ b/ytapp/src/components/LogsPage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { getLogs } from '../features/logs';
+import { getLogs, clearLogs } from '../features/logs';
 import { save } from '@tauri-apps/plugin-dialog';
 import { writeTextFile } from '@tauri-apps/plugin-fs';
 
@@ -20,6 +20,11 @@ const LogsPage: React.FC = () => {
         }
     };
 
+    const doClear = async () => {
+        await clearLogs();
+        setText('');
+    };
+
     useEffect(() => {
         refresh();
     }, []);
@@ -28,6 +33,7 @@ const LogsPage: React.FC = () => {
         <div>
             <button onClick={refresh}>{t('refresh')}</button>
             <button onClick={saveLogs}>{t('save_logs')}</button>
+            <button onClick={doClear}>{t('clear_logs')}</button>
             <pre style={{ whiteSpace: 'pre-wrap', maxHeight: '70vh', overflow: 'auto' }}>{text}</pre>
         </div>
     );

--- a/ytapp/src/features/logs.ts
+++ b/ytapp/src/features/logs.ts
@@ -5,3 +5,8 @@ import { invoke } from '@tauri-apps/api/core';
 export async function getLogs(maxLines = 200): Promise<string> {
   return await invoke('get_logs', { maxLines });
 }
+
+/** Delete the current log file. */
+export async function clearLogs(): Promise<void> {
+  await invoke('clear_logs');
+}

--- a/ytapp/tests/clear_logs.test.ts
+++ b/ytapp/tests/clear_logs.test.ts
@@ -1,0 +1,20 @@
+import assert from 'assert';
+import fs from 'fs/promises';
+const core = require('@tauri-apps/api/core');
+
+(async () => {
+  const file = '/tmp/ytapp.log';
+  await fs.writeFile(file, 'data');
+  core.invoke = async (cmd: string) => {
+    if (cmd === 'clear_logs') await fs.unlink(file);
+  };
+  const { clearLogs } = await import('../src/features/logs');
+  await clearLogs();
+  try {
+    await fs.access(file);
+    assert.fail('log still exists');
+  } catch {
+    // expected
+  }
+  console.log('clear logs feature test passed');
+})();

--- a/ytapp/tests/cli_logs_clear.test.ts
+++ b/ytapp/tests/cli_logs_clear.test.ts
@@ -1,0 +1,13 @@
+import assert from 'assert';
+const core = require('@tauri-apps/api/core');
+const events = require('@tauri-apps/api/event');
+
+(async () => {
+  let called = false;
+  core.invoke = async (cmd: string) => { if (cmd === 'clear_logs') called = true; };
+  events.listen = async () => () => {};
+  process.argv = ['node', 'cli.ts', 'logs-clear'];
+  await import('../src/cli');
+  assert.ok(called);
+  console.log('cli logs-clear test passed');
+})();


### PR DESCRIPTION
## Summary
- support deleting log file in backend
- expose `clear_logs` command
- allow clearing logs from UI and CLI
- include new tests for log clearing
- document how to clear logs via CLI

## Testing
- `cd ytapp && npm install`
- `cd src-tauri && cargo check`
- `cd .. && npx -y ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_68588ca42a3c8331b310239cb886d4fd