### PR TITLE
Add log filtering options

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -462,8 +462,10 @@ npx ts-node src/cli.ts queue-resume
 ```
 View recent logs:
 
+Use `--level` to filter by log level and `--search` to match text within log messages.
+
 ```bash
-npx ts-node src/cli.ts logs 200
+npx ts-node src/cli.ts logs 200 --level error --search failed
 ```
 Clear the log file:
 

--- a/ytapp/src-tauri/src/logger.rs
+++ b/ytapp/src-tauri/src/logger.rs
@@ -3,9 +3,9 @@ use std::io::Write;
 use std::path::PathBuf;
 use tauri::api::path::app_config_dir;
 use chrono::Utc;
-use serde::Serialize;
+use serde::{Serialize, Deserialize};
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 struct LogEntry<'a> {
     level: &'a str,
     message: &'a str,
@@ -34,13 +34,33 @@ pub fn log(app: &tauri::AppHandle, level: &str, message: &str) {
     }
 }
 
-pub fn read_logs(app: &tauri::AppHandle, max_lines: usize) -> Result<String, String> {
+pub fn read_logs(
+    app: &tauri::AppHandle,
+    max_lines: usize,
+    level: Option<String>,
+    search: Option<String>,
+) -> Result<String, String> {
     let path = match log_path(app) {
         Ok(p) => p,
         Err(e) => return Err(e),
     };
     let data = std::fs::read_to_string(path).map_err(|e| e.to_string())?;
-    let lines: Vec<&str> = data.lines().collect();
+    let mut lines = Vec::new();
+    for line in data.lines() {
+        if let Ok(entry) = serde_json::from_str::<LogEntry>(line) {
+            if let Some(ref lvl) = level {
+                if entry.level != lvl {
+                    continue;
+                }
+            }
+            if let Some(ref text) = search {
+                if !entry.message.contains(text) {
+                    continue;
+                }
+            }
+            lines.push(line);
+        }
+    }
     let start = lines.len().saturating_sub(max_lines);
     Ok(lines[start..].join("\n"))
 }

--- a/ytapp/src-tauri/src/main.rs
+++ b/ytapp/src-tauri/src/main.rs
@@ -1344,8 +1344,13 @@ fn install_tauri_deps() -> Result<(), String> {
 }
 
 #[command]
-fn get_logs(app: tauri::AppHandle, max_lines: Option<usize>) -> Result<String, String> {
-    read_logs(&app, max_lines.unwrap_or(200))
+fn get_logs(
+    app: tauri::AppHandle,
+    max_lines: Option<usize>,
+    level: Option<String>,
+    search: Option<String>,
+) -> Result<String, String> {
+    read_logs(&app, max_lines.unwrap_or(200), level, search)
 }
 
 #[command]

--- a/ytapp/src/cli.ts
+++ b/ytapp/src/cli.ts
@@ -1127,10 +1127,12 @@ program
   .command('logs')
   .description('Print recent log entries')
   .argument('[maxLines]', 'number of lines to show')
-  .action(async (maxLines: string | undefined) => {
+  .option('--level <level>', 'filter by level')
+  .option('--search <text>', 'filter by text')
+  .action(async (maxLines: string | undefined, opts: { level?: string; search?: string }) => {
     try {
       const n = parseInt(maxLines || '', 10);
-      const text = await getLogs(isNaN(n) ? 100 : n);
+      const text = await getLogs(isNaN(n) ? 100 : n, opts.level, opts.search);
       console.log(text);
     } catch (err) {
       console.error('Error reading logs:', err);

--- a/ytapp/src/components/LogsPage.tsx
+++ b/ytapp/src/components/LogsPage.tsx
@@ -7,15 +7,19 @@ import { writeTextFile } from '@tauri-apps/plugin-fs';
 const LogsPage: React.FC = () => {
     const { t } = useTranslation();
     const [text, setText] = useState('');
+    const [level, setLevel] = useState('');
+    const [search, setSearch] = useState('');
 
     const refresh = () => {
-        getLogs(200).then(setText).catch(() => setText(''));
+        getLogs(200, level || undefined, search || undefined)
+            .then(setText)
+            .catch(() => setText(''));
     };
 
     const saveLogs = async () => {
         const path = await save({ filters: [{ name: 'Log', extensions: ['log'] }] });
         if (path) {
-            const data = await getLogs(1000);
+            const data = await getLogs(1000, level || undefined, search || undefined);
             await writeTextFile(path, data);
         }
     };
@@ -31,6 +35,16 @@ const LogsPage: React.FC = () => {
 
     return (
         <div>
+            <input
+                placeholder="level"
+                value={level}
+                onChange={(e) => setLevel(e.target.value)}
+            />
+            <input
+                placeholder="search"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+            />
             <button onClick={refresh}>{t('refresh')}</button>
             <button onClick={saveLogs}>{t('save_logs')}</button>
             <button onClick={doClear}>{t('clear_logs')}</button>

--- a/ytapp/src/features/logs.ts
+++ b/ytapp/src/features/logs.ts
@@ -2,8 +2,12 @@
 import { invoke } from '@tauri-apps/api/core';
 
 /** Retrieve recent log lines from the backend. */
-export async function getLogs(maxLines = 200): Promise<string> {
-  return await invoke('get_logs', { maxLines });
+export async function getLogs(
+  maxLines = 200,
+  level?: string,
+  search?: string,
+): Promise<string> {
+  return await invoke('get_logs', { maxLines, level, search });
 }
 
 /** Delete the current log file. */

--- a/ytapp/tests/cli_logs_filter.test.ts
+++ b/ytapp/tests/cli_logs_filter.test.ts
@@ -1,0 +1,15 @@
+import assert from 'assert';
+const core = require('@tauri-apps/api/core');
+const events = require('@tauri-apps/api/event');
+
+(async () => {
+  let args: any;
+  core.invoke = async (cmd: string, a: any) => { if (cmd === 'get_logs') args = a; };
+  events.listen = async () => () => {};
+  process.argv = ['node', 'cli.ts', 'logs', '50', '--level', 'error', '--search', 'fail'];
+  await import('../src/cli');
+  assert.strictEqual(args.maxLines, 50);
+  assert.strictEqual(args.level, 'error');
+  assert.strictEqual(args.search, 'fail');
+  console.log('cli logs filter test passed');
+})();

--- a/ytapp/tests/get_logs_filter.test.ts
+++ b/ytapp/tests/get_logs_filter.test.ts
@@ -1,0 +1,16 @@
+import assert from 'assert';
+const core = require('@tauri-apps/api/core');
+
+(async () => {
+  core.invoke = async (cmd: string, args: any) => {
+    assert.strictEqual(cmd, 'get_logs');
+    assert.strictEqual(args.maxLines, 50);
+    assert.strictEqual(args.level, 'info');
+    assert.strictEqual(args.search, 'foo');
+    return 'ok';
+  };
+  const { getLogs } = await import('../src/features/logs');
+  const text = await getLogs(50, 'info', 'foo');
+  assert.strictEqual(text, 'ok');
+  console.log('get logs filter test passed');
+})();


### PR DESCRIPTION
## Summary
- filter logs by level and search text in backend
- expose optional parameters for logs retrieval in main process
- extend logs API and CLI to use filters
- add filter inputs to LogsPage
- document log filtering options
- test new log filtering features

## Testing
- `npm install`
- `cargo check` *(fails: DNS resolution failure for index.crates.io)*
- `npx ts-node src/cli.ts --help`
- `npx ts-node tests/get_logs_filter.test.ts`
- `npx ts-node tests/cli_logs_filter.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6858c01fddd8833184d246f7ccd97990