### PR TITLE
Add logs output option to CLI

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -463,9 +463,10 @@ npx ts-node src/cli.ts queue-resume
 View recent logs:
 
 Use `--level` to filter by log level and `--search` to match text within log messages.
+Use `--output <file>` to save the logs instead of printing them.
 
 ```bash
-npx ts-node src/cli.ts logs 200 --level error --search failed
+npx ts-node src/cli.ts logs 200 --level error --search failed --output logs.txt
 ```
 Clear the log file:
 

--- a/ytapp/src/cli.ts
+++ b/ytapp/src/cli.ts
@@ -1129,11 +1129,16 @@ program
   .argument('[maxLines]', 'number of lines to show')
   .option('--level <level>', 'filter by level')
   .option('--search <text>', 'filter by text')
-  .action(async (maxLines: string | undefined, opts: { level?: string; search?: string }) => {
+  .option('-o, --output <file>', 'write logs to file')
+  .action(async (maxLines: string | undefined, opts: { level?: string; search?: string; output?: string }) => {
     try {
       const n = parseInt(maxLines || '', 10);
       const text = await getLogs(isNaN(n) ? 100 : n, opts.level, opts.search);
-      console.log(text);
+      if (opts.output) {
+        await fs.writeFile(opts.output, text);
+      } else {
+        console.log(text);
+      }
     } catch (err) {
       console.error('Error reading logs:', err);
       process.exitCode = 1;

--- a/ytapp/tests/cli_logs_output.test.ts
+++ b/ytapp/tests/cli_logs_output.test.ts
@@ -1,0 +1,16 @@
+import assert from 'assert';
+const core = require('@tauri-apps/api/core');
+const events = require('@tauri-apps/api/event');
+const fs = require('fs/promises');
+
+(async () => {
+  let args: any;
+  core.invoke = async (cmd: string, a: any) => { if (cmd === 'get_logs') args = a; };
+  events.listen = async () => () => {};
+  fs.writeFile = async () => {};
+  process.argv = ['node', 'cli.ts', 'logs', '50', '--level', 'info', '--output', '/tmp/out.log'];
+  await import('../src/cli');
+  assert.strictEqual(args.maxLines, 50);
+  // ensure the command executed and invoked get_logs
+  console.log('cli logs output test passed');
+})();


### PR DESCRIPTION
## Summary
- allow saving log output to a file via `--output`
- document the new flag in the README
- test CLI behaviour when using `--output`

## Testing
- `cd ytapp && npm install`
- `cd src-tauri && cargo check`
- `cd .. && npx ts-node src/cli.ts --help`
- `npx ts-node tests/cli_logs_output.test.ts`
- `npx ts-node tests/cli_logs_filter.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6859bd302fe08331bc2b84fc231cdb2d