### PR TITLE
Implement clearFinished queue helper

### DIFF
--- a/ytapp/src/components/QueuePage.tsx
+++ b/ytapp/src/components/QueuePage.tsx
@@ -5,7 +5,7 @@ import {
   runQueue,
   pauseQueue,
   resumeQueue,
-  clearCompleted,
+  clearFinished,
   clearQueue,
   listenQueue,
   removeJob,
@@ -59,7 +59,7 @@ const QueuePage: React.FC = () => {
       <button onClick={() => resumeQueue().then(refresh)} aria-label={t('resume')}>
         {t('resume')}
       </button>
-      <button onClick={() => clearCompleted().then(refresh)}>{t('clear_completed')}</button>
+      <button onClick={() => clearFinished().then(refresh)}>{t('clear_completed')}</button>
       <button onClick={() => clearQueue().then(refresh)}>{t('clear_all')}</button>
       {jobs.map((j, i) => (
         <div

--- a/ytapp/src/components/WatchStatus.tsx
+++ b/ytapp/src/components/WatchStatus.tsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { loadSettings } from '../features/settings';
 import { watchDirectory } from '../features/watch';
-import { listJobs, runQueue, clearCompleted } from '../features/queue';
+import { listJobs, runQueue, clearFinished } from '../features/queue';
 
 const WatchStatus: React.FC = () => {
     const { t } = useTranslation();
@@ -48,7 +48,7 @@ const WatchStatus: React.FC = () => {
             {!auto && (
                 <>
                     <button onClick={process}>{t('process_queue')}</button>
-                    <button onClick={() => clearCompleted()}>{t('clear_completed')}</button>
+                    <button onClick={() => clearFinished()}>{t('clear_completed')}</button>
                 </>
             )}
         </div>

--- a/ytapp/src/features/queue.ts
+++ b/ytapp/src/features/queue.ts
@@ -46,6 +46,12 @@ export async function clearFailed(): Promise<void> {
   await invoke('queue_clear_failed');
 }
 
+/** Remove completed and failed jobs from the queue. */
+export async function clearFinished(): Promise<void> {
+  await clearCompleted();
+  await clearFailed();
+}
+
 export async function runQueue(retryFailed = false): Promise<void> {
   await invoke('queue_process', { retryFailed });
 }

--- a/ytapp/tests/queue_clear_finished.test.ts
+++ b/ytapp/tests/queue_clear_finished.test.ts
@@ -1,0 +1,25 @@
+import assert from 'assert';
+const core = require('@tauri-apps/api/core');
+
+(async () => {
+  let q: any[] = [
+    { job: { Generate: { params: { file: 'a.mp3' }, dest: 'a.mp4' } }, status: 'completed', retries: 0 },
+    { job: { Generate: { params: { file: 'b.mp3' }, dest: 'b.mp4' } }, status: 'failed', retries: 1 },
+    { job: { Generate: { params: { file: 'c.mp3' }, dest: 'c.mp4' } }, status: 'pending', retries: 0 }
+  ];
+  const calls: string[] = [];
+  core.invoke = async (cmd: string) => {
+    calls.push(cmd);
+    if (cmd === 'queue_clear_completed') { q = q.filter(i => i.status !== 'completed'); return; }
+    if (cmd === 'queue_clear_failed') { q = q.filter(i => i.status !== 'failed'); return; }
+    if (cmd === 'queue_list') { return q; }
+  };
+  const { clearFinished, listJobs } = await import('../src/features/queue');
+  await clearFinished();
+  const jobs = await listJobs();
+  assert.strictEqual(jobs.length, 1);
+  const dest = (jobs[0].job as any).Generate.dest;
+  assert.strictEqual(dest, 'c.mp4');
+  assert.deepStrictEqual(calls, ['queue_clear_completed', 'queue_clear_failed']);
+  console.log('queue clearFinished tests passed');
+})();


### PR DESCRIPTION
## Summary
- add `clearFinished` helper that chains clearing completed and failed jobs
- use `clearFinished` in queue UI components
- test that `clearFinished` invokes both backend commands

## Testing
- `npm install`
- `cargo check` *(fails: `gdk-3.0.pc` not found)*
- `npx ts-node src/cli.ts --help`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6859c919358883318d65383bddb47bed