### PR TITLE
Fix gdk-3.0 build issue

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -275,11 +275,12 @@ The CI pipeline runs the same command using the devcontainer image.
 
 ### Troubleshooting `cargo check`
 
-Errors about `glib-2.0`, `glib-sys` or `gobject-sys` usually mean
-`PKG_CONFIG_PATH` is not set. Run `./scripts/setup_codex.sh` (or the
-OS-specific install script such as `scripts/install_tauri_deps.sh`) to install
-the GTK/WebKit packages and create `.env.tauri`. Then **source `.env.tauri`**
-(as noted in `AGENTS.md`) before re-running `cargo check`.
+Errors about `glib-2.0`, `gdk-3.0`, `glib-sys`, `gdk-sys` or `gobject-sys`
+usually mean `PKG_CONFIG_PATH` is not set or the GTK/WebKit development
+packages are missing. Run `./scripts/setup_codex.sh` (or the OS-specific
+install script such as `scripts/install_tauri_deps.sh`) to install the
+dependencies and create `.env.tauri`. Then **source `.env.tauri`** (as noted in
+`AGENTS.md`) before re-running `cargo check`.
 
 To automatically process files placed in a folder set the **Watch Directory**
 and enable **Auto Upload** in the settings page or use the CLI `watch` command.


### PR DESCRIPTION
## Summary
- clarify troubleshooting docs about missing gdk-3.0

## Testing
- `npm install`
- `cargo check`
- `npx -y ts-node src/cli.ts --help`


------
https://chatgpt.com/codex/tasks/task_e_6859f68767248331addeb5c0e16121df