### PR TITLE
Fix queue-clear-completed command

### DIFF
--- a/ytapp/src/cli.ts
+++ b/ytapp/src/cli.ts
@@ -11,7 +11,7 @@ import { translateSrt } from './utils/translate';
 import { parseCsv, CsvRow } from './utils/csv';
 import { watchDirectory } from './features/watch';
 import { generateBatchWithProgress } from './features/batch';
-import { addJob, listJobs, runQueue, clearQueue, clearCompleted, clearFailed, removeJob, moveJob, pauseQueue, resumeQueue } from './features/queue';
+import { addJob, listJobs, runQueue, clearQueue, clearFailed, clearFinished, removeJob, moveJob, pauseQueue, resumeQueue } from './features/queue';
 import { listProfiles, getProfile, saveProfile, deleteProfile } from './features/profiles';
 import { listFonts } from './features/fonts';
 import { fetchPlaylists } from './features/youtube';
@@ -1078,7 +1078,7 @@ program
   .description('Remove completed and failed jobs from the queue')
   .action(async () => {
     try {
-      await clearCompleted();
+      await clearFinished();
     } catch (err) {
       console.error('Error clearing completed and failed jobs:', err);
       process.exitCode = 1;

--- a/ytapp/tests/cli_queue_clear_completed.test.ts
+++ b/ytapp/tests/cli_queue_clear_completed.test.ts
@@ -1,0 +1,14 @@
+import assert from 'assert';
+const core = require('@tauri-apps/api/core');
+const events = require('@tauri-apps/api/event');
+
+(async () => {
+  const calls: string[] = [];
+  core.invoke = async (cmd: string) => { calls.push(cmd); };
+  events.listen = async () => () => {};
+  process.argv = ['node', 'cli.ts', 'queue-clear-completed'];
+  await import('../src/cli');
+  await new Promise(r => setImmediate(r));
+  assert.deepStrictEqual(calls, ['queue_clear_completed', 'queue_clear_failed']);
+  console.log('cli queue-clear-completed test passed');
+})();


### PR DESCRIPTION
## Summary
- call `clearFinished` from queue-clear-completed CLI command
- check for both queue clearing calls in new CLI unit test

## Testing
- `npm install`
- `cargo check`
- `npx ts-node src/cli.ts --help`


------
https://chatgpt.com/codex/tasks/task_e_685b2ff4eb18833184f524ddf75908a8