### PR TITLE
Add theme persistence setting

### DIFF
--- a/ytapp/public/locales/en/translation.json
+++ b/ytapp/public/locales/en/translation.json
@@ -83,6 +83,7 @@
   "playlist": "Playlist",
   "font_search": "Search fonts...",
   "ui_font": "UI Font",
+  "theme": "Theme",
   "logs": "Logs",
   "refresh": "Refresh",
   "save_logs": "Save Logs",

--- a/ytapp/src-tauri/src/main.rs
+++ b/ytapp/src-tauri/src/main.rs
@@ -93,6 +93,7 @@ struct AppSettings {
     caption_bg: Option<String>,
     ui_font: Option<String>,
     accent_color: Option<String>,
+    theme: Option<String>,
     watermark: Option<String>,
     watermark_position: Option<String>,
     show_guide: Option<bool>,
@@ -118,6 +119,7 @@ impl Default for AppSettings {
             caption_bg: None,
             ui_font: None,
             accent_color: None,
+            theme: None,
             watermark: None,
             watermark_position: None,
             show_guide: Some(true),
@@ -932,6 +934,9 @@ fn load_settings(app: tauri::AppHandle) -> Result<AppSettings, String> {
     }
     if settings.max_retries.is_none() {
         settings.max_retries = Some(3);
+    }
+    if settings.theme.is_none() {
+        settings.theme = Some("light".into());
     }
     if settings.profiles.is_empty() {
         settings.profiles = HashMap::new();

--- a/ytapp/src/App.tsx
+++ b/ytapp/src/App.tsx
@@ -106,6 +106,7 @@ const App: React.FC = () => {
                 document.body.style.fontFamily = s.uiFont;
             }
             if (s.accentColor) setAccentColor(s.accentColor);
+            if (s.theme) setTheme(s.theme as any);
             if (s.watermark) setWatermark(s.watermark);
             if (s.watermarkPosition) setWatermarkPos(s.watermarkPosition as any);
             if (s.output) setOutput(s.output);
@@ -141,16 +142,23 @@ const App: React.FC = () => {
         document.documentElement.dir = lang && lang.rtl ? 'rtl' : 'ltr';
     }, [i18n.language]);
 
-    const toggleTheme = () =>
-        setTheme(
+    const toggleTheme = async () => {
+        const next =
             theme === 'light'
                 ? 'dark'
                 : theme === 'dark'
                 ? 'high'
                 : theme === 'high'
                 ? 'solarized'
-                : 'light'
-        );
+                : 'light';
+        setTheme(next);
+        try {
+            const current = await loadSettings();
+            await saveSettings({ ...current, theme: next });
+        } catch {
+            // ignore persistence errors
+        }
+    };
 
 
     const handleTranscriptionComplete = (srts: string[]) => {

--- a/ytapp/src/components/SettingsPage.tsx
+++ b/ytapp/src/components/SettingsPage.tsx
@@ -20,6 +20,7 @@ const SettingsPage: React.FC = () => {
     const [captionBg, setCaptionBg] = useState('#000000');
     const [uiFont, setUiFont] = useState('');
     const [accentColor, setAccentColor] = useState('#ff9500');
+    const [theme, setTheme] = useState<'light' | 'dark' | 'high' | 'solarized'>('light');
     const [watermark, setWatermark] = useState('');
     const [watermarkPos, setWatermarkPos] = useState<'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'>('top-right');
     const [guide, setGuide] = useState(true);
@@ -42,6 +43,7 @@ const SettingsPage: React.FC = () => {
             if (s.captionBg) setCaptionBg(s.captionBg);
             if (s.uiFont) setUiFont(s.uiFont);
             if (s.accentColor) setAccentColor(s.accentColor);
+            if (s.theme) setTheme(s.theme as any);
             if (s.watermark) setWatermark(s.watermark);
             if (s.watermarkPosition) setWatermarkPos(s.watermarkPosition as any);
             setGuide(s.showGuide !== false);
@@ -74,6 +76,7 @@ const SettingsPage: React.FC = () => {
             modelSize,
             maxRetries,
             accentColor,
+            theme,
         });
         document.body.style.fontFamily = uiFont || '';
     };
@@ -173,6 +176,13 @@ const SettingsPage: React.FC = () => {
                 <input type="color" value={captionBg} onChange={e => setCaptionBg(e.target.value)} />
                 <label>Accent</label>
                 <input type="color" value={accentColor} onChange={e => setAccentColor(e.target.value)} />
+                <label>{t('theme')}</label>
+                <select value={theme} onChange={e => setTheme(e.target.value as any)}>
+                    <option value="light">light</option>
+                    <option value="dark">dark</option>
+                    <option value="high">high</option>
+                    <option value="solarized">solarized</option>
+                </select>
             </div>
             <CaptionPreview
                 font={font}

--- a/ytapp/src/features/settings/index.ts
+++ b/ytapp/src/features/settings/index.ts
@@ -21,6 +21,7 @@ export interface Settings {
     output?: string;
     modelSize?: string;
     maxRetries?: number;
+    theme?: string;
 }
 
 export async function loadSettings(): Promise<Settings> {

--- a/ytapp/tests/settings.test.ts
+++ b/ytapp/tests/settings.test.ts
@@ -3,10 +3,11 @@ const core = require('@tauri-apps/api/core');
 
 (async () => {
   core.invoke = async (cmd: string, args: any) => {
-    if (cmd === 'load_settings') return { output: '/tmp/out.mp4', uiFont: 'Arial' };
+    if (cmd === 'load_settings') return { output: '/tmp/out.mp4', uiFont: 'Arial', theme: 'dark' };
     if (cmd === 'save_settings') {
       assert.strictEqual(args.settings.output, '/tmp/out.mp4');
       assert.strictEqual(args.settings.uiFont, 'Arial');
+      assert.strictEqual(args.settings.theme, 'dark');
       return;
     }
   };
@@ -14,6 +15,7 @@ const core = require('@tauri-apps/api/core');
   const s = await loadSettings();
   assert.strictEqual(s.output, '/tmp/out.mp4');
   assert.strictEqual(s.uiFont, 'Arial');
-  await saveSettings({ output: '/tmp/out.mp4', uiFont: 'Arial' });
+  assert.strictEqual(s.theme, 'dark');
+  await saveSettings({ output: '/tmp/out.mp4', uiFont: 'Arial', theme: 'dark' });
   console.log('settings feature tests passed');
 })();


### PR DESCRIPTION
## Summary
- persist the selected theme in settings
- load theme from settings in the main app
- allow updating theme in Settings page
- extend settings tests

## Testing
- `npm install`
- `cargo check` *(fails: glib-2.0 pkg-config missing)*
- `npx ts-node src/cli.ts --help`


------
https://chatgpt.com/codex/tasks/task_e_685b4ac6890c83318d4303af7eaa7b03