### PR TITLE
Persist watermark opacity & scale settings

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -178,7 +178,7 @@ If `cargo check` fails on Linux, run `scripts/install_tauri_deps.sh`.
   * Font selector
   * Size slider
   * Position (top / center / bottom)
-  * Watermark opacity and scale controls
+  * Watermark opacity and scale controls (persisted in settings)
   * Custom accent color setting
 * YouTube sign-in/sign-out buttons
 * Generate video button

--- a/ytapp/src-tauri/src/main.rs
+++ b/ytapp/src-tauri/src/main.rs
@@ -97,6 +97,8 @@ struct AppSettings {
     language: Option<String>,
     watermark: Option<String>,
     watermark_position: Option<String>,
+    watermark_opacity: Option<f32>,
+    watermark_scale: Option<f32>,
     show_guide: Option<bool>,
     watch_dir: Option<String>,
     auto_upload: Option<bool>,
@@ -124,6 +126,8 @@ impl Default for AppSettings {
             language: None,
             watermark: None,
             watermark_position: None,
+            watermark_opacity: Some(1.0),
+            watermark_scale: Some(0.2),
             show_guide: Some(true),
             watch_dir: None,
             auto_upload: Some(false),
@@ -936,6 +940,12 @@ fn load_settings(app: tauri::AppHandle) -> Result<AppSettings, String> {
     }
     if settings.max_retries.is_none() {
         settings.max_retries = Some(3);
+    }
+    if settings.watermark_opacity.is_none() {
+        settings.watermark_opacity = Some(1.0);
+    }
+    if settings.watermark_scale.is_none() {
+        settings.watermark_scale = Some(0.2);
     }
     if settings.theme.is_none() {
         settings.theme = Some("light".into());

--- a/ytapp/src/App.tsx
+++ b/ytapp/src/App.tsx
@@ -110,6 +110,8 @@ const App: React.FC = () => {
             if (s.language) i18n.changeLanguage(s.language);
             if (s.watermark) setWatermark(s.watermark);
             if (s.watermarkPosition) setWatermarkPos(s.watermarkPosition as any);
+            if (typeof s.watermarkOpacity === 'number') setWatermarkOpacity(s.watermarkOpacity);
+            if (typeof s.watermarkScale === 'number') setWatermarkScale(s.watermarkScale);
             if (s.output) setOutput(s.output);
             if (s.showGuide !== false) setShowGuide(true);
             if (s.watchDir) {
@@ -294,6 +296,8 @@ const App: React.FC = () => {
             captionBg: captionBg,
             watermark: watermark || undefined,
             watermarkPosition: watermarkPos,
+            watermarkOpacity,
+            watermarkScale,
             output: output || undefined,
             showGuide: false,
         });

--- a/ytapp/src/components/SettingsPage.tsx
+++ b/ytapp/src/components/SettingsPage.tsx
@@ -23,6 +23,8 @@ const SettingsPage: React.FC = () => {
     const [theme, setTheme] = useState<'light' | 'dark' | 'high' | 'solarized'>('light');
     const [watermark, setWatermark] = useState('');
     const [watermarkPos, setWatermarkPos] = useState<'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'>('top-right');
+    const [watermarkOpacity, setWatermarkOpacity] = useState(1);
+    const [watermarkScale, setWatermarkScale] = useState(0.2);
     const [guide, setGuide] = useState(true);
     const [watchDir, setWatchDir] = useState('');
     const [autoUpload, setAutoUpload] = useState(false);
@@ -46,6 +48,8 @@ const SettingsPage: React.FC = () => {
             if (s.theme) setTheme(s.theme as any);
             if (s.watermark) setWatermark(s.watermark);
             if (s.watermarkPosition) setWatermarkPos(s.watermarkPosition as any);
+            if (typeof s.watermarkOpacity === 'number') setWatermarkOpacity(s.watermarkOpacity);
+            if (typeof s.watermarkScale === 'number') setWatermarkScale(s.watermarkScale);
             setGuide(s.showGuide !== false);
             setWatchDir(s.watchDir || '');
             setAutoUpload(!!s.autoUpload);
@@ -69,6 +73,8 @@ const SettingsPage: React.FC = () => {
             uiFont: uiFont || undefined,
             watermark: watermark || undefined,
             watermarkPosition: watermarkPos,
+            watermarkOpacity,
+            watermarkScale,
             showGuide: guide,
             watchDir: watchDir || undefined,
             autoUpload,
@@ -147,6 +153,12 @@ const SettingsPage: React.FC = () => {
                     <option value="bottom-left">{t('bottom_left')}</option>
                     <option value="bottom-right">{t('bottom_right')}</option>
                 </select>
+            </div>
+            <div>
+                <label>{t('watermark_opacity')}</label>
+                <input type="number" min="0" max="1" step="0.05" value={watermarkOpacity} onChange={e => setWatermarkOpacity(parseFloat(e.target.value))} />
+                <label>{t('watermark_scale')}</label>
+                <input type="number" min="0" max="1" step="0.05" value={watermarkScale} onChange={e => setWatermarkScale(parseFloat(e.target.value))} />
             </div>
             <div>
                 <FontSelector

--- a/ytapp/src/features/settings/index.ts
+++ b/ytapp/src/features/settings/index.ts
@@ -15,6 +15,8 @@ export interface Settings {
     accentColor?: string;
     watermark?: string;
     watermarkPosition?: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+    watermarkOpacity?: number;
+    watermarkScale?: number;
     showGuide?: boolean;
     watchDir?: string;
     autoUpload?: boolean;

--- a/ytapp/tests/settings.test.ts
+++ b/ytapp/tests/settings.test.ts
@@ -3,12 +3,14 @@ const core = require('@tauri-apps/api/core');
 
 (async () => {
   core.invoke = async (cmd: string, args: any) => {
-    if (cmd === 'load_settings') return { output: '/tmp/out.mp4', uiFont: 'Arial', theme: 'dark', language: 'fr' };
+    if (cmd === 'load_settings') return { output: '/tmp/out.mp4', uiFont: 'Arial', theme: 'dark', language: 'fr', watermarkOpacity: 0.8, watermarkScale: 0.3 };
     if (cmd === 'save_settings') {
       assert.strictEqual(args.settings.output, '/tmp/out.mp4');
       assert.strictEqual(args.settings.uiFont, 'Arial');
       assert.strictEqual(args.settings.theme, 'dark');
       assert.strictEqual(args.settings.language, 'fr');
+      assert.strictEqual(args.settings.watermarkOpacity, 0.8);
+      assert.strictEqual(args.settings.watermarkScale, 0.3);
       return;
     }
   };
@@ -18,6 +20,8 @@ const core = require('@tauri-apps/api/core');
   assert.strictEqual(s.uiFont, 'Arial');
   assert.strictEqual(s.theme, 'dark');
   assert.strictEqual(s.language, 'fr');
-  await saveSettings({ output: '/tmp/out.mp4', uiFont: 'Arial', theme: 'dark', language: 'fr' });
+  assert.strictEqual(s.watermarkOpacity, 0.8);
+  assert.strictEqual(s.watermarkScale, 0.3);
+  await saveSettings({ output: '/tmp/out.mp4', uiFont: 'Arial', theme: 'dark', language: 'fr', watermarkOpacity: 0.8, watermarkScale: 0.3 });
   console.log('settings feature tests passed');
 })();


### PR DESCRIPTION
## Summary
- persist watermark opacity and scale in settings
- expose these values in TS settings API and UI
- restore them from saved settings on launch
- document persistence in README
- update unit tests

## Testing
- `npm install`
- `cargo check`
- `npx ts-node src/cli.ts --help`
- `npx ts-node tests/settings.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_685ca30f9b2c8331aa483787a94efcfb