### PR TITLE
Add default resolution to settings

### DIFF
--- a/docs/deep_dive.md
+++ b/docs/deep_dive.md
@@ -51,7 +51,7 @@ The `ytapp` directory hosts both the frontend code (React/TypeScript) and the Ru
 - **components/** – Reusable React components.
   - `FilePicker.tsx` and `DropZone.tsx` handle file selection and drag‑and‑drop.
   - `BatchProcessor.tsx`, `BatchUploader.tsx` and `BatchOptionsForm.tsx` implement batch generation and upload UIs.
-  - `SettingsPage.tsx` persists default options via the settings API.
+  - `SettingsPage.tsx` persists default options (including default resolution) via the settings API.
   - `ProfilesPage.tsx` manages saved profiles.
   - `QueuePage.tsx` shows queued jobs and allows reordering.
   - `LogsPage.tsx` displays application logs.

--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,7 @@ If `cargo check` fails on Linux, run `scripts/install_tauri_deps.sh`.
     * Burn captions into video via FFmpeg
   * Optional Outro (user-provided video or image)
   * Output: Final video (H.264 MP4)
-  * Configurable resolution via `--width`/`--height` or UI dropdown
+  * Configurable resolution via `--width`/`--height`, UI dropdown and default settings
   * Supports vertical short-form formats (720x1280 and 1080x1920)
 
 ---

--- a/ytapp/src-tauri/src/main.rs
+++ b/ytapp/src-tauri/src/main.rs
@@ -105,6 +105,8 @@ struct AppSettings {
     output: Option<String>,
     model_size: Option<String>,
     max_retries: Option<u32>,
+    default_width: Option<u32>,
+    default_height: Option<u32>,
     profiles: HashMap<String, Profile>,
 }
 
@@ -134,6 +136,8 @@ impl Default for AppSettings {
             output: None,
             model_size: Some("base".into()),
             max_retries: Some(3),
+            default_width: Some(1280),
+            default_height: Some(720),
             profiles: HashMap::new(),
         }
     }
@@ -940,6 +944,12 @@ fn load_settings(app: tauri::AppHandle) -> Result<AppSettings, String> {
     }
     if settings.max_retries.is_none() {
         settings.max_retries = Some(3);
+    }
+    if settings.default_width.is_none() {
+        settings.default_width = Some(1280);
+    }
+    if settings.default_height.is_none() {
+        settings.default_height = Some(720);
     }
     if settings.watermark_opacity.is_none() {
         settings.watermark_opacity = Some(1.0);

--- a/ytapp/src/App.tsx
+++ b/ytapp/src/App.tsx
@@ -113,6 +113,8 @@ const App: React.FC = () => {
             if (typeof s.watermarkOpacity === 'number') setWatermarkOpacity(s.watermarkOpacity);
             if (typeof s.watermarkScale === 'number') setWatermarkScale(s.watermarkScale);
             if (s.output) setOutput(s.output);
+            if (typeof s.defaultWidth === 'number') setWidth(s.defaultWidth);
+            if (typeof s.defaultHeight === 'number') setHeight(s.defaultHeight);
             if (s.showGuide !== false) setShowGuide(true);
             if (s.watchDir) {
                 watchDirectory(s.watchDir, { autoUpload: s.autoUpload });

--- a/ytapp/src/components/SettingsPage.tsx
+++ b/ytapp/src/components/SettingsPage.tsx
@@ -31,6 +31,8 @@ const SettingsPage: React.FC = () => {
     const [modelSize, setModelSize] = useState('base');
     const [output, setOutput] = useState('');
     const [maxRetries, setMaxRetries] = useState(3);
+    const [width, setWidth] = useState(1280);
+    const [height, setHeight] = useState(720);
 
     useEffect(() => {
         loadSettings().then(s => {
@@ -56,6 +58,8 @@ const SettingsPage: React.FC = () => {
             setOutput(s.output || '');
             if (s.modelSize) setModelSize(s.modelSize);
             if (typeof s.maxRetries === 'number') setMaxRetries(s.maxRetries);
+            if (typeof s.defaultWidth === 'number') setWidth(s.defaultWidth);
+            if (typeof s.defaultHeight === 'number') setHeight(s.defaultHeight);
         });
     }, []);
 
@@ -81,6 +85,8 @@ const SettingsPage: React.FC = () => {
             output: output || undefined,
             modelSize,
             maxRetries,
+            defaultWidth: width,
+            defaultHeight: height,
             accentColor,
             theme,
         });
@@ -203,6 +209,23 @@ const SettingsPage: React.FC = () => {
                 background={captionBg}
                 position="bottom"
             />
+            <div>
+                <label>{t('resolution')}</label>
+                <select
+                    value={`${width}x${height}`}
+                    onChange={e => {
+                        const [w, h] = e.target.value.split('x').map(v => parseInt(v, 10));
+                        setWidth(w);
+                        setHeight(h);
+                    }}
+                >
+                    <option value="640x360">640x360</option>
+                    <option value="1280x720">1280x720</option>
+                    <option value="1920x1080">1920x1080</option>
+                    <option value="720x1280">720x1280</option>
+                    <option value="1080x1920">1080x1920</option>
+                </select>
+            </div>
             <div>
                 <label>{t('whisper_size')}</label>
                 <select value={modelSize} onChange={e => setModelSize(e.target.value)}>

--- a/ytapp/src/features/settings/index.ts
+++ b/ytapp/src/features/settings/index.ts
@@ -23,6 +23,8 @@ export interface Settings {
     output?: string;
     modelSize?: string;
     maxRetries?: number;
+    defaultWidth?: number;
+    defaultHeight?: number;
     theme?: string;
     language?: string;
 }

--- a/ytapp/tests/settings.test.ts
+++ b/ytapp/tests/settings.test.ts
@@ -3,7 +3,7 @@ const core = require('@tauri-apps/api/core');
 
 (async () => {
   core.invoke = async (cmd: string, args: any) => {
-    if (cmd === 'load_settings') return { output: '/tmp/out.mp4', uiFont: 'Arial', theme: 'dark', language: 'fr', watermarkOpacity: 0.8, watermarkScale: 0.3 };
+    if (cmd === 'load_settings') return { output: '/tmp/out.mp4', uiFont: 'Arial', theme: 'dark', language: 'fr', watermarkOpacity: 0.8, watermarkScale: 0.3, defaultWidth: 640, defaultHeight: 360 };
     if (cmd === 'save_settings') {
       assert.strictEqual(args.settings.output, '/tmp/out.mp4');
       assert.strictEqual(args.settings.uiFont, 'Arial');
@@ -11,6 +11,8 @@ const core = require('@tauri-apps/api/core');
       assert.strictEqual(args.settings.language, 'fr');
       assert.strictEqual(args.settings.watermarkOpacity, 0.8);
       assert.strictEqual(args.settings.watermarkScale, 0.3);
+      assert.strictEqual(args.settings.defaultWidth, 640);
+      assert.strictEqual(args.settings.defaultHeight, 360);
       return;
     }
   };
@@ -22,6 +24,8 @@ const core = require('@tauri-apps/api/core');
   assert.strictEqual(s.language, 'fr');
   assert.strictEqual(s.watermarkOpacity, 0.8);
   assert.strictEqual(s.watermarkScale, 0.3);
-  await saveSettings({ output: '/tmp/out.mp4', uiFont: 'Arial', theme: 'dark', language: 'fr', watermarkOpacity: 0.8, watermarkScale: 0.3 });
+  assert.strictEqual(s.defaultWidth, 640);
+  assert.strictEqual(s.defaultHeight, 360);
+  await saveSettings({ output: '/tmp/out.mp4', uiFont: 'Arial', theme: 'dark', language: 'fr', watermarkOpacity: 0.8, watermarkScale: 0.3, defaultWidth: 640, defaultHeight: 360 });
   console.log('settings feature tests passed');
 })();


### PR DESCRIPTION
## Summary
- allow storing a default video resolution in `AppSettings`
- expose `defaultWidth` and `defaultHeight` to TypeScript
- let users choose this resolution in `SettingsPage`
- initialize width/height from the defaults in `App.tsx`
- document new feature and update tests

## Testing
- `cd ytapp && npm install`
- `cd src-tauri && cargo check`
- `cd .. && npx ts-node src/cli.ts --help`


------
https://chatgpt.com/codex/tasks/task_e_685cb1dbb8908331820485bde06530ed