### PR TITLE
Update locales with watermark keys

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,8 @@ Thank you for helping improve this project!
    ```
 2. Add a directory `ytapp/public/locales/<code>` containing `translation.json`.
    Start with `{ "title": "Youtube Automation" }` if you don't have full translations.
-3. Run `make verify` or the individual commands in `AGENTS.md` before committing.
+3. Run `node scripts/update_locales.js` to populate any new keys in every locale file.
+4. Run `make verify` or the individual commands in `AGENTS.md` before committing.
    If `cargo check` fails, run `scripts/install_tauri_deps.sh`.
 
 ## Development

--- a/scripts/update_locales.js
+++ b/scripts/update_locales.js
@@ -13,7 +13,11 @@ const extras = {
   update_prompt: 'A new version is ready to install.',
   update_now: 'Update Now',
   later: 'Later',
-  font_search: 'Search fonts...'
+  font_search: 'Search fonts...',
+  watermark: 'Watermark',
+  watermark_position: 'Watermark Position',
+  watermark_opacity: 'Watermark Opacity',
+  watermark_scale: 'Watermark Scale'
 };
 const keys = { ...onboarding, ...extras };
 for (const locale of fs.readdirSync(localeDir)) {

--- a/ytapp/public/locales/af/translation.json
+++ b/ytapp/public/locales/af/translation.json
@@ -22,5 +22,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/ar/translation.json
+++ b/ytapp/public/locales/ar/translation.json
@@ -61,5 +61,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/az/translation.json
+++ b/ytapp/public/locales/az/translation.json
@@ -22,5 +22,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/be/translation.json
+++ b/ytapp/public/locales/be/translation.json
@@ -22,5 +22,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/bg/translation.json
+++ b/ytapp/public/locales/bg/translation.json
@@ -61,5 +61,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/bn/translation.json
+++ b/ytapp/public/locales/bn/translation.json
@@ -22,5 +22,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/bs/translation.json
+++ b/ytapp/public/locales/bs/translation.json
@@ -22,5 +22,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/ca/translation.json
+++ b/ytapp/public/locales/ca/translation.json
@@ -22,5 +22,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/cs/translation.json
+++ b/ytapp/public/locales/cs/translation.json
@@ -61,5 +61,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/cy/translation.json
+++ b/ytapp/public/locales/cy/translation.json
@@ -22,5 +22,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/da/translation.json
+++ b/ytapp/public/locales/da/translation.json
@@ -61,5 +61,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/de/translation.json
+++ b/ytapp/public/locales/de/translation.json
@@ -57,5 +57,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/el/translation.json
+++ b/ytapp/public/locales/el/translation.json
@@ -61,5 +61,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/es/translation.json
+++ b/ytapp/public/locales/es/translation.json
@@ -61,5 +61,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/et/translation.json
+++ b/ytapp/public/locales/et/translation.json
@@ -22,5 +22,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/eu/translation.json
+++ b/ytapp/public/locales/eu/translation.json
@@ -22,5 +22,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/fa/translation.json
+++ b/ytapp/public/locales/fa/translation.json
@@ -22,5 +22,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/fi/translation.json
+++ b/ytapp/public/locales/fi/translation.json
@@ -61,5 +61,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/fr/translation.json
+++ b/ytapp/public/locales/fr/translation.json
@@ -61,5 +61,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/gl/translation.json
+++ b/ytapp/public/locales/gl/translation.json
@@ -22,5 +22,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/gu/translation.json
+++ b/ytapp/public/locales/gu/translation.json
@@ -22,5 +22,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/he/translation.json
+++ b/ytapp/public/locales/he/translation.json
@@ -61,5 +61,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/hi/translation.json
+++ b/ytapp/public/locales/hi/translation.json
@@ -61,5 +61,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/hr/translation.json
+++ b/ytapp/public/locales/hr/translation.json
@@ -61,5 +61,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/hu/translation.json
+++ b/ytapp/public/locales/hu/translation.json
@@ -61,5 +61,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/hy/translation.json
+++ b/ytapp/public/locales/hy/translation.json
@@ -22,5 +22,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/id/translation.json
+++ b/ytapp/public/locales/id/translation.json
@@ -61,5 +61,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/is/translation.json
+++ b/ytapp/public/locales/is/translation.json
@@ -22,5 +22,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/it/translation.json
+++ b/ytapp/public/locales/it/translation.json
@@ -61,5 +61,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/ja/translation.json
+++ b/ytapp/public/locales/ja/translation.json
@@ -57,5 +57,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/kk/translation.json
+++ b/ytapp/public/locales/kk/translation.json
@@ -22,5 +22,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/kn/translation.json
+++ b/ytapp/public/locales/kn/translation.json
@@ -22,5 +22,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/ko/translation.json
+++ b/ytapp/public/locales/ko/translation.json
@@ -61,5 +61,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/lt/translation.json
+++ b/ytapp/public/locales/lt/translation.json
@@ -61,5 +61,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/lv/translation.json
+++ b/ytapp/public/locales/lv/translation.json
@@ -61,5 +61,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/mi/translation.json
+++ b/ytapp/public/locales/mi/translation.json
@@ -22,5 +22,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/mk/translation.json
+++ b/ytapp/public/locales/mk/translation.json
@@ -22,5 +22,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/mr/translation.json
+++ b/ytapp/public/locales/mr/translation.json
@@ -22,5 +22,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/ms/translation.json
+++ b/ytapp/public/locales/ms/translation.json
@@ -61,5 +61,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/ne/translation.json
+++ b/ytapp/public/locales/ne/translation.json
@@ -61,5 +61,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/nl/translation.json
+++ b/ytapp/public/locales/nl/translation.json
@@ -61,5 +61,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/nn/translation.json
+++ b/ytapp/public/locales/nn/translation.json
@@ -22,5 +22,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/no/translation.json
+++ b/ytapp/public/locales/no/translation.json
@@ -61,5 +61,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/pa/translation.json
+++ b/ytapp/public/locales/pa/translation.json
@@ -22,5 +22,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/pl/translation.json
+++ b/ytapp/public/locales/pl/translation.json
@@ -61,5 +61,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/pt/translation.json
+++ b/ytapp/public/locales/pt/translation.json
@@ -57,5 +57,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/ro/translation.json
+++ b/ytapp/public/locales/ro/translation.json
@@ -61,5 +61,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/ru/translation.json
+++ b/ytapp/public/locales/ru/translation.json
@@ -57,5 +57,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/sk/translation.json
+++ b/ytapp/public/locales/sk/translation.json
@@ -61,5 +61,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/sl/translation.json
+++ b/ytapp/public/locales/sl/translation.json
@@ -22,5 +22,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/sq/translation.json
+++ b/ytapp/public/locales/sq/translation.json
@@ -22,5 +22,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/sr/translation.json
+++ b/ytapp/public/locales/sr/translation.json
@@ -22,5 +22,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/sv/translation.json
+++ b/ytapp/public/locales/sv/translation.json
@@ -61,5 +61,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/sw/translation.json
+++ b/ytapp/public/locales/sw/translation.json
@@ -22,5 +22,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/ta/translation.json
+++ b/ytapp/public/locales/ta/translation.json
@@ -22,5 +22,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/te/translation.json
+++ b/ytapp/public/locales/te/translation.json
@@ -22,5 +22,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/th/translation.json
+++ b/ytapp/public/locales/th/translation.json
@@ -61,5 +61,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/tl/translation.json
+++ b/ytapp/public/locales/tl/translation.json
@@ -22,5 +22,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/tr/translation.json
+++ b/ytapp/public/locales/tr/translation.json
@@ -61,5 +61,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/uk/translation.json
+++ b/ytapp/public/locales/uk/translation.json
@@ -61,5 +61,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/ur/translation.json
+++ b/ytapp/public/locales/ur/translation.json
@@ -61,5 +61,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/vi/translation.json
+++ b/ytapp/public/locales/vi/translation.json
@@ -61,5 +61,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }

--- a/ytapp/public/locales/zh/translation.json
+++ b/ytapp/public/locales/zh/translation.json
@@ -61,5 +61,9 @@
   "update_now": "Update Now",
   "later": "Later",
   "playlist": "Playlist",
-  "font_search": "Search fonts..."
+  "font_search": "Search fonts...",
+  "watermark": "Watermark",
+  "watermark_position": "Watermark Position",
+  "watermark_opacity": "Watermark Opacity",
+  "watermark_scale": "Watermark Scale"
 }


### PR DESCRIPTION
## Summary
- add watermark strings to locale updater
- document running `update_locales.js`
- populate missing watermark keys for all locales

## Testing
- `cd ytapp && npm install`
- `cd src-tauri && cargo check`
- `cd .. && npx ts-node src/cli.ts --help`


------
https://chatgpt.com/codex/tasks/task_e_685cb59634408331bf3c4870620707f6