### PR TITLE
Add default upload settings

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -193,6 +193,7 @@ If `cargo check` fails on Linux, run `scripts/install_tauri_deps.sh`.
 * Thumbnail selector in the GUI
 * Output path picker for generated videos
 * Settings page with persistent defaults
+* Default privacy and playlist settings for uploads
 * Profiles page to save and load sets of options
  * Interface translations are handled via i18n files in `public/locales`.
    Over 60 languages are supported and fall back to English when a
@@ -287,6 +288,10 @@ To automatically process files placed in a folder set the **Watch Directory**
 and enable **Auto Upload** in the settings page or use the CLI `watch` command.
 When the app starts it will immediately begin watching the configured folder using your saved settings.
 Run `npx ts-node src/cli.ts watch-stop` to disable watching again.
+
+Default upload options such as privacy level and playlist ID can also be
+configured in the Settings page. They are stored in `settings.json` under
+`default_privacy` and `default_playlist_id`.
 
 ### Contribution
 

--- a/ytapp/src-tauri/src/main.rs
+++ b/ytapp/src-tauri/src/main.rs
@@ -105,6 +105,8 @@ struct AppSettings {
     output: Option<String>,
     model_size: Option<String>,
     max_retries: Option<u32>,
+    default_privacy: Option<String>,
+    default_playlist_id: Option<String>,
     profiles: HashMap<String, Profile>,
 }
 
@@ -134,6 +136,8 @@ impl Default for AppSettings {
             output: None,
             model_size: Some("base".into()),
             max_retries: Some(3),
+            default_privacy: Some("public".into()),
+            default_playlist_id: None,
             profiles: HashMap::new(),
         }
     }
@@ -940,6 +944,12 @@ fn load_settings(app: tauri::AppHandle) -> Result<AppSettings, String> {
     }
     if settings.max_retries.is_none() {
         settings.max_retries = Some(3);
+    }
+    if settings.default_privacy.is_none() {
+        settings.default_privacy = Some("public".into());
+    }
+    if settings.default_playlist_id.is_none() {
+        settings.default_playlist_id = None;
     }
     if settings.watermark_opacity.is_none() {
         settings.watermark_opacity = Some(1.0);

--- a/ytapp/src/App.tsx
+++ b/ytapp/src/App.tsx
@@ -117,6 +117,8 @@ const App: React.FC = () => {
             if (s.watchDir) {
                 watchDirectory(s.watchDir, { autoUpload: s.autoUpload });
             }
+            if (s.defaultPrivacy) setPrivacy(s.defaultPrivacy);
+            if (s.defaultPlaylistId) setPlaylistId(s.defaultPlaylistId);
         });
         check().then(res => {
             if (res) setShowUpdate(true);

--- a/ytapp/src/components/SettingsPage.tsx
+++ b/ytapp/src/components/SettingsPage.tsx
@@ -31,6 +31,8 @@ const SettingsPage: React.FC = () => {
     const [modelSize, setModelSize] = useState('base');
     const [output, setOutput] = useState('');
     const [maxRetries, setMaxRetries] = useState(3);
+    const [defaultPrivacy, setDefaultPrivacy] = useState('public');
+    const [defaultPlaylistId, setDefaultPlaylistId] = useState('');
 
     useEffect(() => {
         loadSettings().then(s => {
@@ -56,6 +58,8 @@ const SettingsPage: React.FC = () => {
             setOutput(s.output || '');
             if (s.modelSize) setModelSize(s.modelSize);
             if (typeof s.maxRetries === 'number') setMaxRetries(s.maxRetries);
+            if (s.defaultPrivacy) setDefaultPrivacy(s.defaultPrivacy);
+            if (s.defaultPlaylistId) setDefaultPlaylistId(s.defaultPlaylistId);
         });
     }, []);
 
@@ -83,6 +87,8 @@ const SettingsPage: React.FC = () => {
             maxRetries,
             accentColor,
             theme,
+            defaultPrivacy: defaultPrivacy || undefined,
+            defaultPlaylistId: defaultPlaylistId || undefined,
         });
         document.body.style.fontFamily = uiFont || '';
     };
@@ -222,6 +228,16 @@ const SettingsPage: React.FC = () => {
             <div>
                 <label>{t('max_retries')}</label>
                 <input type="number" min="1" value={maxRetries} onChange={e => setMaxRetries(parseInt(e.target.value, 10) || 1)} />
+            </div>
+            <div>
+                <label>{t('privacy')}</label>
+                <select value={defaultPrivacy} onChange={e => setDefaultPrivacy(e.target.value)}>
+                    <option value="public">public</option>
+                    <option value="unlisted">unlisted</option>
+                    <option value="private">private</option>
+                </select>
+                <label>{t('playlist')}</label>
+                <input type="text" value={defaultPlaylistId} onChange={e => setDefaultPlaylistId(e.target.value)} />
             </div>
             <button onClick={handleSave}>{t('save')}</button>
         </div>

--- a/ytapp/src/features/settings/index.ts
+++ b/ytapp/src/features/settings/index.ts
@@ -25,6 +25,8 @@ export interface Settings {
     maxRetries?: number;
     theme?: string;
     language?: string;
+    defaultPrivacy?: string;
+    defaultPlaylistId?: string;
 }
 
 export async function loadSettings(): Promise<Settings> {

--- a/ytapp/tests/settings.test.ts
+++ b/ytapp/tests/settings.test.ts
@@ -3,7 +3,7 @@ const core = require('@tauri-apps/api/core');
 
 (async () => {
   core.invoke = async (cmd: string, args: any) => {
-    if (cmd === 'load_settings') return { output: '/tmp/out.mp4', uiFont: 'Arial', theme: 'dark', language: 'fr', watermarkOpacity: 0.8, watermarkScale: 0.3 };
+    if (cmd === 'load_settings') return { output: '/tmp/out.mp4', uiFont: 'Arial', theme: 'dark', language: 'fr', watermarkOpacity: 0.8, watermarkScale: 0.3, defaultPrivacy: 'unlisted', defaultPlaylistId: 'PL123' };
     if (cmd === 'save_settings') {
       assert.strictEqual(args.settings.output, '/tmp/out.mp4');
       assert.strictEqual(args.settings.uiFont, 'Arial');
@@ -11,6 +11,8 @@ const core = require('@tauri-apps/api/core');
       assert.strictEqual(args.settings.language, 'fr');
       assert.strictEqual(args.settings.watermarkOpacity, 0.8);
       assert.strictEqual(args.settings.watermarkScale, 0.3);
+      assert.strictEqual(args.settings.defaultPrivacy, 'unlisted');
+      assert.strictEqual(args.settings.defaultPlaylistId, 'PL123');
       return;
     }
   };
@@ -22,6 +24,8 @@ const core = require('@tauri-apps/api/core');
   assert.strictEqual(s.language, 'fr');
   assert.strictEqual(s.watermarkOpacity, 0.8);
   assert.strictEqual(s.watermarkScale, 0.3);
-  await saveSettings({ output: '/tmp/out.mp4', uiFont: 'Arial', theme: 'dark', language: 'fr', watermarkOpacity: 0.8, watermarkScale: 0.3 });
+  assert.strictEqual(s.defaultPrivacy, 'unlisted');
+  assert.strictEqual(s.defaultPlaylistId, 'PL123');
+  await saveSettings({ output: '/tmp/out.mp4', uiFont: 'Arial', theme: 'dark', language: 'fr', watermarkOpacity: 0.8, watermarkScale: 0.3, defaultPrivacy: 'unlisted', defaultPlaylistId: 'PL123' });
   console.log('settings feature tests passed');
 })();


### PR DESCRIPTION
## Summary
- extend `AppSettings` with `default_privacy` and `default_playlist_id`
- handle new values in load and save logic
- expose fields in TypeScript settings interface
- add privacy and playlist inputs to settings page
- load defaults in main app state
- document options and update tests

## Testing
- `make verify`
- `cd ytapp/src-tauri && cargo check --quiet`
- `npx ts-node ytapp/src/cli.ts --help`
- `for f in ytapp/tests/*.ts; do npx ts-node "$f" || true; done` *(fails: AssertionError due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_685cb1dbf2888331815a04b53c3e0a05