### PR TITLE
Add default privacy settings

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -476,6 +476,7 @@ Clear the log file:
 npx ts-node src/cli.ts logs-clear
 ```
 The maximum retry count is configurable in the Settings page or by `max_retries` in `settings.json` (default `3`).
+Default privacy and playlist can also be saved in the Settings page or via `default_privacy` and `default_playlist_id` in `settings.json`.
 
 Profiles can store commonly used generation options in `settings.json`.
 Save a profile from a JSON file:

--- a/ytapp/src-tauri/src/main.rs
+++ b/ytapp/src-tauri/src/main.rs
@@ -105,6 +105,8 @@ struct AppSettings {
     output: Option<String>,
     model_size: Option<String>,
     max_retries: Option<u32>,
+    default_privacy: Option<String>,
+    default_playlist_id: Option<String>,
     profiles: HashMap<String, Profile>,
 }
 
@@ -134,6 +136,8 @@ impl Default for AppSettings {
             output: None,
             model_size: Some("base".into()),
             max_retries: Some(3),
+            default_privacy: Some("public".into()),
+            default_playlist_id: None,
             profiles: HashMap::new(),
         }
     }
@@ -940,6 +944,12 @@ fn load_settings(app: tauri::AppHandle) -> Result<AppSettings, String> {
     }
     if settings.max_retries.is_none() {
         settings.max_retries = Some(3);
+    }
+    if settings.default_privacy.is_none() {
+        settings.default_privacy = Some("public".into());
+    }
+    if settings.default_playlist_id.is_none() {
+        settings.default_playlist_id = None;
     }
     if settings.watermark_opacity.is_none() {
         settings.watermark_opacity = Some(1.0);

--- a/ytapp/src/App.tsx
+++ b/ytapp/src/App.tsx
@@ -113,6 +113,8 @@ const App: React.FC = () => {
             if (typeof s.watermarkOpacity === 'number') setWatermarkOpacity(s.watermarkOpacity);
             if (typeof s.watermarkScale === 'number') setWatermarkScale(s.watermarkScale);
             if (s.output) setOutput(s.output);
+            if (s.defaultPrivacy) setPrivacy(s.defaultPrivacy);
+            if (s.defaultPlaylistId) setPlaylistId(s.defaultPlaylistId);
             if (s.showGuide !== false) setShowGuide(true);
             if (s.watchDir) {
                 watchDirectory(s.watchDir, { autoUpload: s.autoUpload });

--- a/ytapp/src/components/SettingsPage.tsx
+++ b/ytapp/src/components/SettingsPage.tsx
@@ -6,6 +6,7 @@ import FontSelector from './FontSelector';
 import SizeSlider from './SizeSlider';
 import CaptionPreview from './CaptionPreview';
 import { loadSettings, saveSettings } from '../features/settings';
+import PlaylistSelector from './PlaylistSelector';
 
 const SettingsPage: React.FC = () => {
     const { t } = useTranslation();
@@ -31,6 +32,8 @@ const SettingsPage: React.FC = () => {
     const [modelSize, setModelSize] = useState('base');
     const [output, setOutput] = useState('');
     const [maxRetries, setMaxRetries] = useState(3);
+    const [defaultPrivacy, setDefaultPrivacy] = useState<'public' | 'unlisted' | 'private'>('public');
+    const [defaultPlaylistId, setDefaultPlaylistId] = useState('');
 
     useEffect(() => {
         loadSettings().then(s => {
@@ -56,6 +59,8 @@ const SettingsPage: React.FC = () => {
             setOutput(s.output || '');
             if (s.modelSize) setModelSize(s.modelSize);
             if (typeof s.maxRetries === 'number') setMaxRetries(s.maxRetries);
+            if (s.defaultPrivacy) setDefaultPrivacy(s.defaultPrivacy as any);
+            if (s.defaultPlaylistId) setDefaultPlaylistId(s.defaultPlaylistId);
         });
     }, []);
 
@@ -83,6 +88,8 @@ const SettingsPage: React.FC = () => {
             maxRetries,
             accentColor,
             theme,
+            defaultPrivacy,
+            defaultPlaylistId,
         });
         document.body.style.fontFamily = uiFont || '';
     };
@@ -222,6 +229,16 @@ const SettingsPage: React.FC = () => {
             <div>
                 <label>{t('max_retries')}</label>
                 <input type="number" min="1" value={maxRetries} onChange={e => setMaxRetries(parseInt(e.target.value, 10) || 1)} />
+            </div>
+            <div>
+                <label>{t('privacy')}</label>
+                <select value={defaultPrivacy} onChange={e => setDefaultPrivacy(e.target.value as any)}>
+                    <option value="public">public</option>
+                    <option value="unlisted">unlisted</option>
+                    <option value="private">private</option>
+                </select>
+                <label>{t('playlist')}</label>
+                <PlaylistSelector value={defaultPlaylistId} onChange={setDefaultPlaylistId} />
             </div>
             <button onClick={handleSave}>{t('save')}</button>
         </div>

--- a/ytapp/src/features/settings/index.ts
+++ b/ytapp/src/features/settings/index.ts
@@ -25,6 +25,8 @@ export interface Settings {
     maxRetries?: number;
     theme?: string;
     language?: string;
+    defaultPrivacy?: string;
+    defaultPlaylistId?: string;
 }
 
 export async function loadSettings(): Promise<Settings> {

--- a/ytapp/tests/settings.test.ts
+++ b/ytapp/tests/settings.test.ts
@@ -3,7 +3,7 @@ const core = require('@tauri-apps/api/core');
 
 (async () => {
   core.invoke = async (cmd: string, args: any) => {
-    if (cmd === 'load_settings') return { output: '/tmp/out.mp4', uiFont: 'Arial', theme: 'dark', language: 'fr', watermarkOpacity: 0.8, watermarkScale: 0.3 };
+    if (cmd === 'load_settings') return { output: '/tmp/out.mp4', uiFont: 'Arial', theme: 'dark', language: 'fr', watermarkOpacity: 0.8, watermarkScale: 0.3, defaultPrivacy: 'private', defaultPlaylistId: 'PL123' };
     if (cmd === 'save_settings') {
       assert.strictEqual(args.settings.output, '/tmp/out.mp4');
       assert.strictEqual(args.settings.uiFont, 'Arial');
@@ -11,6 +11,8 @@ const core = require('@tauri-apps/api/core');
       assert.strictEqual(args.settings.language, 'fr');
       assert.strictEqual(args.settings.watermarkOpacity, 0.8);
       assert.strictEqual(args.settings.watermarkScale, 0.3);
+      assert.strictEqual(args.settings.defaultPrivacy, 'private');
+      assert.strictEqual(args.settings.defaultPlaylistId, 'PL123');
       return;
     }
   };
@@ -22,6 +24,8 @@ const core = require('@tauri-apps/api/core');
   assert.strictEqual(s.language, 'fr');
   assert.strictEqual(s.watermarkOpacity, 0.8);
   assert.strictEqual(s.watermarkScale, 0.3);
-  await saveSettings({ output: '/tmp/out.mp4', uiFont: 'Arial', theme: 'dark', language: 'fr', watermarkOpacity: 0.8, watermarkScale: 0.3 });
+  assert.strictEqual(s.defaultPrivacy, 'private');
+  assert.strictEqual(s.defaultPlaylistId, 'PL123');
+  await saveSettings({ output: '/tmp/out.mp4', uiFont: 'Arial', theme: 'dark', language: 'fr', watermarkOpacity: 0.8, watermarkScale: 0.3, defaultPrivacy: 'private', defaultPlaylistId: 'PL123' });
   console.log('settings feature tests passed');
 })();


### PR DESCRIPTION
## Summary
- extend AppSettings with privacy and playlist defaults
- expose those defaults through settings APIs
- add privacy and playlist selectors on the settings page
- initialize main app state from saved defaults
- document new options
- test default settings handling

## Testing
- `cd ytapp && npm install`
- `cd src-tauri && cargo check`
- `cd .. && npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_685cb5943f288331b8cd4ddec747c911