### PR TITLE
Integrate upload defaults and update resolution

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,7 @@ If `cargo check` fails on Linux, run `scripts/install_tauri_deps.sh`.
     * Burn captions into video via FFmpeg
   * Optional Outro (user-provided video or image)
   * Output: Final video (H.264 MP4)
-  * Configurable resolution via `--width`/`--height`, UI dropdown and default settings
+  * Configurable resolution via `--width`/`--height` or UI dropdown, with a default set in Settings
   * Supports vertical short-form formats (720x1280 and 1080x1920)
 
 ---
@@ -192,7 +192,7 @@ If `cargo check` fails on Linux, run `scripts/install_tauri_deps.sh`.
 * Improved focus outlines and ARIA labels on modal and file picker buttons
 * Thumbnail selector in the GUI
 * Output path picker for generated videos
-* Settings page with persistent defaults
+* Settings page with persistent defaults (resolution, privacy and playlist)
 * Profiles page to save and load sets of options
  * Interface translations are handled via i18n files in `public/locales`.
    Over 60 languages are supported and fall back to English when a

--- a/ytapp/public/locales/en/translation.json
+++ b/ytapp/public/locales/en/translation.json
@@ -80,6 +80,7 @@
   "update_prompt": "A new version is ready to install.",
   "update_now": "Update Now",
   "later": "Later",
+  "privacy": "Privacy",
   "playlist": "Playlist",
   "font_search": "Search fonts...",
   "ui_font": "UI Font",

--- a/ytapp/src-tauri/src/main.rs
+++ b/ytapp/src-tauri/src/main.rs
@@ -107,6 +107,8 @@ struct AppSettings {
     max_retries: Option<u32>,
     default_width: Option<u32>,
     default_height: Option<u32>,
+    default_privacy: Option<String>,
+    default_playlist_id: Option<String>,
     profiles: HashMap<String, Profile>,
 }
 
@@ -136,8 +138,10 @@ impl Default for AppSettings {
             output: None,
             model_size: Some("base".into()),
             max_retries: Some(3),
-            default_width: Some(1280),
-            default_height: Some(720),
+            default_width: Some(1920),
+            default_height: Some(1080),
+            default_privacy: Some("public".into()),
+            default_playlist_id: None,
             profiles: HashMap::new(),
         }
     }
@@ -946,10 +950,16 @@ fn load_settings(app: tauri::AppHandle) -> Result<AppSettings, String> {
         settings.max_retries = Some(3);
     }
     if settings.default_width.is_none() {
-        settings.default_width = Some(1280);
+        settings.default_width = Some(1920);
     }
     if settings.default_height.is_none() {
-        settings.default_height = Some(720);
+        settings.default_height = Some(1080);
+    }
+    if settings.default_privacy.is_none() {
+        settings.default_privacy = Some("public".into());
+    }
+    if settings.default_playlist_id.is_none() {
+        settings.default_playlist_id = None;
     }
     if settings.watermark_opacity.is_none() {
         settings.watermark_opacity = Some(1.0);

--- a/ytapp/src/App.tsx
+++ b/ytapp/src/App.tsx
@@ -56,8 +56,8 @@ const App: React.FC = () => {
     const [size, setSize] = useState(24);
     const [position, setPosition] = useState('bottom');
     const [language, setLanguage] = useState<Language>('auto');
-    const [width, setWidth] = useState(1280);
-    const [height, setHeight] = useState(720);
+    const [width, setWidth] = useState(1920);
+    const [height, setHeight] = useState(1080);
     const [theme, setTheme] = useState<'light' | 'dark' | 'high' | 'solarized'>(() => {
         const stored = localStorage.getItem('theme');
         if (stored === 'dark' || stored === 'high' || stored === 'light' || stored === 'solarized') {
@@ -115,6 +115,8 @@ const App: React.FC = () => {
             if (s.output) setOutput(s.output);
             if (typeof s.defaultWidth === 'number') setWidth(s.defaultWidth);
             if (typeof s.defaultHeight === 'number') setHeight(s.defaultHeight);
+            if (s.defaultPrivacy) setPrivacy(s.defaultPrivacy);
+            if (s.defaultPlaylistId) setPlaylistId(s.defaultPlaylistId);
             if (s.showGuide !== false) setShowGuide(true);
             if (s.watchDir) {
                 watchDirectory(s.watchDir, { autoUpload: s.autoUpload });

--- a/ytapp/src/components/BatchOptionsForm.tsx
+++ b/ytapp/src/components/BatchOptionsForm.tsx
@@ -102,7 +102,7 @@ const BatchOptionsForm: React.FC<BatchOptionsFormProps> = ({ value, onChange }) 
             <div className="row">
                 <label>{t('resolution')}</label>
                 <select
-                    value={`${value.width || 1280}x${value.height || 720}`}
+                    value={`${value.width || 1920}x${value.height || 1080}`}
                     onChange={e => {
                         const [w, h] = e.target.value.split('x').map(v => parseInt(v, 10));
                         update({ width: w, height: h });

--- a/ytapp/src/components/SettingsPage.tsx
+++ b/ytapp/src/components/SettingsPage.tsx
@@ -5,6 +5,7 @@ import FilePicker from './FilePicker';
 import FontSelector from './FontSelector';
 import SizeSlider from './SizeSlider';
 import CaptionPreview from './CaptionPreview';
+import PlaylistSelector from './PlaylistSelector';
 import { loadSettings, saveSettings } from '../features/settings';
 
 const SettingsPage: React.FC = () => {
@@ -31,8 +32,10 @@ const SettingsPage: React.FC = () => {
     const [modelSize, setModelSize] = useState('base');
     const [output, setOutput] = useState('');
     const [maxRetries, setMaxRetries] = useState(3);
-    const [width, setWidth] = useState(1280);
-    const [height, setHeight] = useState(720);
+    const [width, setWidth] = useState(1920);
+    const [height, setHeight] = useState(1080);
+    const [defaultPrivacy, setDefaultPrivacy] = useState<'public' | 'unlisted' | 'private'>('public');
+    const [defaultPlaylistId, setDefaultPlaylistId] = useState('');
 
     useEffect(() => {
         loadSettings().then(s => {
@@ -60,6 +63,8 @@ const SettingsPage: React.FC = () => {
             if (typeof s.maxRetries === 'number') setMaxRetries(s.maxRetries);
             if (typeof s.defaultWidth === 'number') setWidth(s.defaultWidth);
             if (typeof s.defaultHeight === 'number') setHeight(s.defaultHeight);
+            if (s.defaultPrivacy) setDefaultPrivacy(s.defaultPrivacy as any);
+            if (s.defaultPlaylistId) setDefaultPlaylistId(s.defaultPlaylistId);
         });
     }, []);
 
@@ -89,6 +94,8 @@ const SettingsPage: React.FC = () => {
             defaultHeight: height,
             accentColor,
             theme,
+            defaultPrivacy,
+            defaultPlaylistId,
         });
         document.body.style.fontFamily = uiFont || '';
     };
@@ -202,13 +209,6 @@ const SettingsPage: React.FC = () => {
                     <option value="solarized">solarized</option>
                 </select>
             </div>
-            <CaptionPreview
-                font={font}
-                size={size}
-                color={captionColor}
-                background={captionBg}
-                position="bottom"
-            />
             <div>
                 <label>{t('resolution')}</label>
                 <select
@@ -226,6 +226,13 @@ const SettingsPage: React.FC = () => {
                     <option value="1080x1920">1080x1920</option>
                 </select>
             </div>
+            <CaptionPreview
+                font={font}
+                size={size}
+                color={captionColor}
+                background={captionBg}
+                position="bottom"
+            />
             <div>
                 <label>{t('whisper_size')}</label>
                 <select value={modelSize} onChange={e => setModelSize(e.target.value)}>
@@ -245,6 +252,16 @@ const SettingsPage: React.FC = () => {
             <div>
                 <label>{t('max_retries')}</label>
                 <input type="number" min="1" value={maxRetries} onChange={e => setMaxRetries(parseInt(e.target.value, 10) || 1)} />
+            </div>
+            <div>
+                <label>{t('privacy')}</label>
+                <select value={defaultPrivacy} onChange={e => setDefaultPrivacy(e.target.value as any)}>
+                    <option value="public">public</option>
+                    <option value="unlisted">unlisted</option>
+                    <option value="private">private</option>
+                </select>
+                <label>{t('playlist')}</label>
+                <PlaylistSelector value={defaultPlaylistId} onChange={setDefaultPlaylistId} />
             </div>
             <button onClick={handleSave}>{t('save')}</button>
         </div>

--- a/ytapp/src/features/settings/index.ts
+++ b/ytapp/src/features/settings/index.ts
@@ -25,6 +25,8 @@ export interface Settings {
     maxRetries?: number;
     defaultWidth?: number;
     defaultHeight?: number;
+    defaultPrivacy?: string;
+    defaultPlaylistId?: string;
     theme?: string;
     language?: string;
 }

--- a/ytapp/tests/settings.test.ts
+++ b/ytapp/tests/settings.test.ts
@@ -3,7 +3,7 @@ const core = require('@tauri-apps/api/core');
 
 (async () => {
   core.invoke = async (cmd: string, args: any) => {
-    if (cmd === 'load_settings') return { output: '/tmp/out.mp4', uiFont: 'Arial', theme: 'dark', language: 'fr', watermarkOpacity: 0.8, watermarkScale: 0.3, defaultWidth: 640, defaultHeight: 360 };
+    if (cmd === 'load_settings') return { output: '/tmp/out.mp4', uiFont: 'Arial', theme: 'dark', language: 'fr', watermarkOpacity: 0.8, watermarkScale: 0.3, defaultWidth: 1920, defaultHeight: 1080, defaultPrivacy: 'private', defaultPlaylistId: 'PL123' };
     if (cmd === 'save_settings') {
       assert.strictEqual(args.settings.output, '/tmp/out.mp4');
       assert.strictEqual(args.settings.uiFont, 'Arial');
@@ -11,8 +11,10 @@ const core = require('@tauri-apps/api/core');
       assert.strictEqual(args.settings.language, 'fr');
       assert.strictEqual(args.settings.watermarkOpacity, 0.8);
       assert.strictEqual(args.settings.watermarkScale, 0.3);
-      assert.strictEqual(args.settings.defaultWidth, 640);
-      assert.strictEqual(args.settings.defaultHeight, 360);
+      assert.strictEqual(args.settings.defaultWidth, 1920);
+      assert.strictEqual(args.settings.defaultHeight, 1080);
+      assert.strictEqual(args.settings.defaultPrivacy, 'private');
+      assert.strictEqual(args.settings.defaultPlaylistId, 'PL123');
       return;
     }
   };
@@ -24,8 +26,10 @@ const core = require('@tauri-apps/api/core');
   assert.strictEqual(s.language, 'fr');
   assert.strictEqual(s.watermarkOpacity, 0.8);
   assert.strictEqual(s.watermarkScale, 0.3);
-  assert.strictEqual(s.defaultWidth, 640);
-  assert.strictEqual(s.defaultHeight, 360);
-  await saveSettings({ output: '/tmp/out.mp4', uiFont: 'Arial', theme: 'dark', language: 'fr', watermarkOpacity: 0.8, watermarkScale: 0.3, defaultWidth: 640, defaultHeight: 360 });
+  assert.strictEqual(s.defaultWidth, 1920);
+  assert.strictEqual(s.defaultHeight, 1080);
+  assert.strictEqual(s.defaultPrivacy, 'private');
+  assert.strictEqual(s.defaultPlaylistId, 'PL123');
+  await saveSettings({ output: '/tmp/out.mp4', uiFont: 'Arial', theme: 'dark', language: 'fr', watermarkOpacity: 0.8, watermarkScale: 0.3, defaultWidth: 1920, defaultHeight: 1080, defaultPrivacy: 'private', defaultPlaylistId: 'PL123' });
   console.log('settings feature tests passed');
 })();


### PR DESCRIPTION
## Summary
- add `defaultPrivacy` and `defaultPlaylistId` fields
- move caption preview below resolution selector
- expose new defaults in settings page and app
- set default resolution to 1920x1080
- document new settings and update translations
- adjust tests for new fields

## Testing
- `npm install`
- `cargo check`
- `npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_685cc24bd800833196b5ab20082f7c59