### PR TITLE
Add npm test runner

### DIFF
--- a/docs/deep_dive.md
+++ b/docs/deep_dive.md
@@ -17,7 +17,7 @@ This document provides an overview of every major file and module in the reposit
 ### Top Level Files
 
 - **AGENTS.md** – Defines the required verification commands and overall guidelines. It instructs developers to run `npm install`, `cargo check`, and `ts-node src/cli.ts --help` before committing. It also explains the devcontainer setup.
-- **Makefile** – Implements the `verify`, `dev`, `test`, and `package` targets. `make verify` runs linting, TypeScript compilation, `cargo check`, and a CLI help check.
+- **Makefile** – Implements the `verify`, `dev`, `test`, and `package` targets. `make verify` runs linting, TypeScript compilation, `cargo check`, and a CLI help check. The `test` target runs each TypeScript test sequentially; you can alternatively run `npm test` inside `ytapp`.
 - **readme.md** – Extensive implementation plan covering every feature: audio processing, transcription, YouTube integration, batch tools, UI design, packaging, setup and CLI usage.
 - **scripts/** – Contains bash and Node scripts used for setup, packaging and translation updates.
   - `setup.sh` installs toolchains and dependencies.

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,7 @@ make dev                 # launches the Tauri app
 
 Before every commit run `make verify` (or the commands in `AGENTS.md`).
 If `cargo check` fails on Linux, run `scripts/install_tauri_deps.sh`.
+Run `make test` (or `npm test` inside `ytapp`) to run the automated tests.
 
 ---
 

--- a/ytapp/package.json
+++ b/ytapp/package.json
@@ -7,7 +7,8 @@
     "build": "vite build",
     "cli": "ts-node src/cli.ts",
     "lint": "tsc --noEmit",
-    "a11y-test": "node scripts/a11y-test.js"
+    "a11y-test": "node scripts/a11y-test.js",
+    "test": "cd .. && ts-node scripts/generate-schema.ts && ts-node ytapp/tests/run-all.ts"
   },
   "dependencies": {
     "@tauri-apps/api": "^2.5.0",

--- a/ytapp/tests/run-all.ts
+++ b/ytapp/tests/run-all.ts
@@ -1,0 +1,15 @@
+import { readdirSync } from 'fs';
+import path from 'path';
+
+(async () => {
+  const files = readdirSync(__dirname)
+    .filter(f => f.endsWith('.test.ts'))
+    .sort();
+  for (const f of files) {
+    try {
+      await import(path.join(__dirname, f));
+    } catch (err) {
+      console.error(err);
+    }
+  }
+})();


### PR DESCRIPTION
## Summary
- run all tests with `npm test`
- document npm test as alternative in README and docs

## Testing
- `npm install`
- `cargo check`
- `ts-node src/cli.ts --help`
- `npm test` *(fails: Module './schema' has no exported member 'Profile')*

------
https://chatgpt.com/codex/tasks/task_e_685efa7dcc58833182e1644ca3a0e5a5