### PR TITLE
Update verify target to generate schema

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ its variables are available before running any checks.
 Run the following commands before committing changes:
 
 ```bash
+npx ts-node scripts/generate-schema.ts
 cd ytapp && npm install
 cd src-tauri && cargo check
 cd .. && npx ts-node src/cli.ts --help

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
-.PHONY: dev test package verify lint ts rust cli
+.PHONY: dev test package verify lint ts rust cli schema
 
 # Use globally installed ts-node if available, otherwise fallback to npx.
 TS_NODE := $(shell command -v ts-node >/dev/null 2>&1 && echo ts-node || echo npx ts-node)
 
-verify: lint ts rust cli
+verify: schema lint ts rust cli
 	@echo "✅  All dev checks passed"
+
+schema:
+	$(TS_NODE) --project ytapp/tsconfig.json scripts/generate-schema.ts
 
 lint:
 	cd ytapp && npm run lint
@@ -20,13 +23,13 @@ cli:
 
 dev:
 	@echo "Running development checks"
-	$(TS_NODE) scripts/generate-schema.ts
+	$(TS_NODE) --project ytapp/tsconfig.json scripts/generate-schema.ts
 	cd ytapp && npm install
 	cd ytapp/src-tauri && cargo check
 	cd ../.. && $(TS_NODE) ytapp/src/cli.ts --help
 
 test:
-	$(TS_NODE) scripts/generate-schema.ts
+	$(TS_NODE) --project ytapp/tsconfig.json scripts/generate-schema.ts
 	cd ytapp && npx tsc --noEmit
 	for f in ytapp/tests/*.ts; do $(TS_NODE) "$f" || true; done
 	cd ytapp/src-tauri && cargo test --all-targets || true

--- a/docs/deep_dive.md
+++ b/docs/deep_dive.md
@@ -16,8 +16,8 @@ This document provides an overview of every major file and module in the reposit
 
 ### Top Level Files
 
-- **AGENTS.md** – Defines the required verification commands and overall guidelines. It instructs developers to run `npm install`, `cargo check`, and `ts-node src/cli.ts --help` before committing. It also explains the devcontainer setup.
-- **Makefile** – Implements the `verify`, `dev`, `test`, and `package` targets. `make verify` runs linting, TypeScript compilation, `cargo check`, and a CLI help check.
+- **AGENTS.md** – Defines the required verification commands and overall guidelines. It instructs developers to run `scripts/generate-schema.ts`, `npm install`, `cargo check`, and `ts-node src/cli.ts --help` before committing. It also explains the devcontainer setup.
+- **Makefile** – Implements the `verify`, `dev`, `test`, and `package` targets. `make verify` generates the shared schema then runs linting, TypeScript compilation, `cargo check`, and a CLI help check.
 - **readme.md** – Extensive implementation plan covering every feature: audio processing, transcription, YouTube integration, batch tools, UI design, packaging, setup and CLI usage.
 - **scripts/** – Contains bash and Node scripts used for setup, packaging and translation updates.
   - `setup.sh` installs toolchains and dependencies.
@@ -103,7 +103,7 @@ The Rust side exposes commands to the frontend via Tauri. Major files include:
 ## Next Steps for Contributors
 
 1. **Set up the environment** using `scripts/setup_codex.sh` or the devcontainer image. Source `.env.tauri` before running Rust commands.
-2. **Run `make verify`** (or the individual commands in `AGENTS.md`) to ensure TypeScript, Rust and CLI checks pass.
+2. **Run `make verify`** (or the individual commands in `AGENTS.md`) to generate the shared schema and ensure TypeScript, Rust and CLI checks pass.
 3. **Frontend changes** should go in `ytapp/src` – React components or feature modules. Keep indentation consistent (2 spaces for `.ts`, 4 for `.tsx`).
 4. **Backend changes** belong under `ytapp/src-tauri/src`. Add new Tauri commands here and expose them through small wrappers under `src/features`.
 5. **Add documentation** in `docs/` when introducing significant features.

--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,8 @@ make dev                 # launches the Tauri app
 ```
 
 Before every commit run `make verify` (or the commands in `AGENTS.md`).
+This command first runs `scripts/generate-schema.ts` to keep TypeScript and Rust
+schemas in sync before linting and compilation.
 If `cargo check` fails on Linux, run `scripts/install_tauri_deps.sh`.
 
 ---
@@ -263,7 +265,8 @@ Codex and all contributors should open the repo using the prebuilt image `ghcr.i
 The same setup steps are mirrored in `.codex/Dockerfile` which Codex uses as a
 bootstrap container.
 
-Before committing run `make verify` or the steps in `AGENTS.md`:
+Before committing run `make verify` or the steps in `AGENTS.md`.
+`make verify` runs `scripts/generate-schema.ts` first, then lints and compiles:
 ```bash
 make verify
 ```


### PR DESCRIPTION
## Summary
- generate schema before linting
- document schema step in AGENTS and README
- mention verify sequence in docs

## Testing
- `npx ts-node --project ytapp/tsconfig.json scripts/generate-schema.ts`
- `cd ytapp && npm install`
- `cd src-tauri && cargo check`
- `cd .. && npx ts-node src/cli.ts --help`
- `make verify` *(fails: lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685efa7ce3dc8331b221674aef473dda