### PR TITLE
Fix duplicate watermark keys

### DIFF
--- a/scripts/update_locales.js
+++ b/scripts/update_locales.js
@@ -20,14 +20,7 @@ const extras = {
   watermark_scale: 'Watermark Scale'
 };
 
-const watermark = {
-  watermark: 'Watermark',
-  watermark_position: 'Watermark Position',
-  watermark_opacity: 'Watermark Opacity',
-  watermark_scale: 'Watermark Scale'
-};
-
-const keys = { ...onboarding, ...extras, ...watermark };
+const keys = { ...onboarding, ...extras };
 for (const locale of fs.readdirSync(localeDir)) {
   const file = path.join(localeDir, locale, 'translation.json');
   const data = JSON.parse(fs.readFileSync(file, 'utf8'));


### PR DESCRIPTION
## Summary
- clean up update_locales.js

## Testing
- `cd ytapp && npm install`
- `cd src-tauri && cargo check --quiet` *(fails: `gobject-sys` not found)*
- `cd .. && npx ts-node src/cli.ts --help`
- `make verify` *(fails: `gobject-sys` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685efa7f411883318a346b31184ee612