### PR TITLE
Fix schema generation & CLI imports

### DIFF
--- a/ytapp/src/cli.ts
+++ b/ytapp/src/cli.ts
@@ -6,7 +6,7 @@ import path from 'path';
 import { spawn } from 'child_process';
 import fs from 'fs/promises';
 import os from 'os';
-import { CaptionOptions, GenerateParams } from './schema';
+import type { CaptionOptions, GenerateParams } from './schema';
 import { translateSrt } from './utils/translate';
 import { parseCsv, CsvRow } from './utils/csv';
 import { watchDirectory } from './features/watch';


### PR DESCRIPTION
## Summary
- update schema generation script to include missing fields
- add Profile interface in generated schema
- mark CLI schema imports as type-only

## Testing
- `npx ts-node --project ytapp/tsconfig.json scripts/generate-schema.ts`
- `npm install`
- `cargo check`
- `npx ts-node src/cli.ts --help`


------
https://chatgpt.com/codex/tasks/task_e_685f2310dfd8833185dd1f80ff2c1cc4