### PR TITLE
Add CLI command to shift SRT timings

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -479,6 +479,11 @@ Clear the log file:
 ```bash
 npx ts-node src/cli.ts logs-clear
 ```
+Shift all timestamps in an SRT file forward by 1.5 seconds:
+
+```bash
+npx ts-node src/cli.ts shift-srt captions.srt 1.5 --output adjusted.srt
+```
 The maximum retry count is configurable in the Settings page or by `max_retries` in `settings.json` (default `3`).
 
 Profiles can store commonly used generation options in `settings.json`.

--- a/ytapp/src/cli.ts
+++ b/ytapp/src/cli.ts
@@ -1158,6 +1158,22 @@ program
   });
 
 program
+  .command('shift-srt')
+  .description('Shift SRT timestamps by the given offset in seconds')
+  .argument('<file>', 'subtitle file')
+  .argument('<offset>', 'offset in seconds')
+  .option('-o, --output <file>', 'write to different file')
+  .action(async (file: string, offset: string, opts: { output?: string }) => {
+    try {
+      const { shiftSrt } = await import('./utils/srt');
+      await shiftSrt(file, parseFloat(offset), opts.output);
+    } catch (err) {
+      console.error('Error shifting srt:', err);
+      process.exitCode = 1;
+    }
+  });
+
+program
   .command('edit-srt')
   .description('Edit an SRT file using $EDITOR')
   .argument('<file>', 'subtitle file')

--- a/ytapp/src/utils/srt.ts
+++ b/ytapp/src/utils/srt.ts
@@ -1,0 +1,55 @@
+export function parseTime(time: string): number {
+  const m = time.match(/(\d+):(\d+):(\d+),(\d+)/);
+  if (!m) return 0;
+  const [, h, mnt, s, ms] = m;
+  return (
+    parseInt(h, 10) * 3600000 +
+    parseInt(mnt, 10) * 60000 +
+    parseInt(s, 10) * 1000 +
+    parseInt(ms, 10)
+  );
+}
+
+export function formatTime(ms: number): string {
+  if (ms < 0) ms = 0;
+  const h = Math.floor(ms / 3600000);
+  ms %= 3600000;
+  const mnt = Math.floor(ms / 60000);
+  ms %= 60000;
+  const s = Math.floor(ms / 1000);
+  const msec = ms % 1000;
+  return (
+    String(h).padStart(2, '0') +
+    ':' +
+    String(mnt).padStart(2, '0') +
+    ':' +
+    String(s).padStart(2, '0') +
+    ',' +
+    String(msec).padStart(3, '0')
+  );
+}
+
+/**
+ * Shift all timestamps in an SRT file by the given offset in seconds.
+ * Returns the path to the output file.
+ */
+export async function shiftSrt(
+  input: string,
+  offset: number,
+  output?: string
+): Promise<string> {
+  const fs = await import('fs/promises');
+  const data = await fs.readFile(input, 'utf-8');
+  const lines = data.split(/\r?\n/);
+  const re = /(\d{2}:\d{2}:\d{2},\d{3}) --> (\d{2}:\d{2}:\d{2},\d{3})/;
+  const outLines = lines.map((l) => {
+    const m = l.match(re);
+    if (!m) return l;
+    const start = parseTime(m[1]) + offset * 1000;
+    const end = parseTime(m[2]) + offset * 1000;
+    return formatTime(start) + ' --> ' + formatTime(end);
+  });
+  const dest = output || input;
+  await fs.writeFile(dest, outLines.join('\n'));
+  return dest;
+}

--- a/ytapp/tests/cli_shift_srt.test.ts
+++ b/ytapp/tests/cli_shift_srt.test.ts
@@ -1,0 +1,17 @@
+import assert from 'assert';
+import fs from 'fs/promises';
+const core = require('@tauri-apps/api/core');
+const events = require('@tauri-apps/api/event');
+
+(async () => {
+  const path = '/tmp/shift.srt';
+  await fs.writeFile(path, '1\n00:00:00,000 --> 00:00:01,000\nhi\n');
+  core.invoke = async () => {};
+  events.listen = async () => () => {};
+  process.argv = ['node', 'cli.ts', 'shift-srt', path, '1'];
+  await import('../src/cli');
+  await new Promise(r => setTimeout(r, 10));
+  const data = await fs.readFile(path, 'utf-8');
+  assert.ok(data.includes('00:00:01,000 --> 00:00:02,000'));
+  console.log('cli shift-srt test passed');
+})();


### PR DESCRIPTION
## Summary
- add `shift-srt` command to CLI
- implement `shiftSrt` utility for editing subtitle timestamps
- document usage in README
- add test covering `shift-srt` command

## Testing
- `node --loader ./ytapp/node_modules/ts-node/esm.mjs scripts/generate-schema.ts`
- `cd ytapp/src-tauri && cargo check`
- `npx ts-node ytapp/src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_685f4ab41b508331a7ae5c351d0e6694