### PR TITLE
Add queue import/export

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -438,6 +438,14 @@ Move a job within the queue:
 ```bash
 npx ts-node src/cli.ts queue-move 2 0
 ```
+Export the queue to a file:
+```bash
+npx ts-node src/cli.ts queue-export queue.json
+```
+Import a queue from a file, appending to existing jobs:
+```bash
+npx ts-node src/cli.ts queue-import queue.json --append
+```
 Each job now tracks a `status` and `retries` count in `queue.json`.
 Failed jobs remain in the queue until they succeed or exceed the retry limit.
 

--- a/ytapp/src-tauri/src/main.rs
+++ b/ytapp/src-tauri/src/main.rs
@@ -1060,6 +1060,18 @@ fn queue_clear_failed(app: tauri::AppHandle) -> Result<(), String> {
 }
 
 #[command]
+fn queue_export(app: tauri::AppHandle, path: String) -> Result<(), String> {
+    load_queue(&app).ok();
+    job_queue::export_queue(&app, &path)
+}
+
+#[command]
+fn queue_import(app: tauri::AppHandle, path: String, append: Option<bool>) -> Result<(), String> {
+    load_queue(&app).ok();
+    job_queue::import_queue(&app, &path, append.unwrap_or(false))
+}
+
+#[command]
 fn queue_pause(_app: tauri::AppHandle) {
     job_queue::set_paused(true);
     job_queue::notifier().notify_one();
@@ -1427,7 +1439,7 @@ fn main() {
             }
             Ok(())
         })
-        .invoke_handler(tauri::generate_handler![generate_video, upload_video, upload_videos, transcribe_audio, generate_upload, generate_batch_upload, watch_directory, youtube_sign_in, youtube_sign_out, youtube_is_signed_in, list_playlists, load_settings, save_settings, load_srt, save_srt, cancel_generate, cancel_upload, queue_add, queue_list, queue_remove, queue_move, queue_clear, queue_clear_completed, queue_clear_failed, queue_pause, queue_resume, queue_process, profile_list, profile_get, profile_save, profile_delete, verify_dependencies, install_tauri_deps, list_fonts, get_logs, clear_logs_cmd])
+        .invoke_handler(tauri::generate_handler![generate_video, upload_video, upload_videos, transcribe_audio, generate_upload, generate_batch_upload, watch_directory, youtube_sign_in, youtube_sign_out, youtube_is_signed_in, list_playlists, load_settings, save_settings, load_srt, save_srt, cancel_generate, cancel_upload, queue_add, queue_list, queue_remove, queue_move, queue_clear, queue_clear_completed, queue_clear_failed, queue_export, queue_import, queue_pause, queue_resume, queue_process, profile_list, profile_get, profile_save, profile_delete, verify_dependencies, install_tauri_deps, list_fonts, get_logs, clear_logs_cmd])
         .run(context)
         .expect("error while running tauri application");
 }

--- a/ytapp/src/cli.ts
+++ b/ytapp/src/cli.ts
@@ -11,7 +11,7 @@ import { translateSrt } from './utils/translate';
 import { parseCsv, CsvRow } from './utils/csv';
 import { watchDirectory } from './features/watch';
 import { generateBatchWithProgress } from './features/batch';
-import { addJob, listJobs, runQueue, clearQueue, clearFailed, clearFinished, removeJob, moveJob, pauseQueue, resumeQueue } from './features/queue';
+import { addJob, listJobs, runQueue, clearQueue, clearFailed, clearFinished, removeJob, moveJob, pauseQueue, resumeQueue, exportQueue, importQueue } from './features/queue';
 import { listProfiles, getProfile, saveProfile, deleteProfile } from './features/profiles';
 import { listFonts } from './features/fonts';
 import { fetchPlaylists } from './features/youtube';
@@ -1045,6 +1045,33 @@ program
       await moveJob(parseInt(from, 10), parseInt(to, 10));
     } catch (err) {
       console.error('Error moving job:', err);
+      process.exitCode = 1;
+    }
+  });
+
+program
+  .command('queue-export')
+  .description('Export queue to a JSON file')
+  .argument('<file>', 'output file')
+  .action(async (file: string) => {
+    try {
+      await exportQueue(file);
+    } catch (err) {
+      console.error('Error exporting queue:', err);
+      process.exitCode = 1;
+    }
+  });
+
+program
+  .command('queue-import')
+  .description('Import queue from a JSON file')
+  .argument('<file>', 'input file')
+  .option('--append', 'append to existing queue')
+  .action(async (file: string, opts: { append?: boolean }) => {
+    try {
+      await importQueue(file, !!opts.append);
+    } catch (err) {
+      console.error('Error importing queue:', err);
       process.exitCode = 1;
     }
   });

--- a/ytapp/src/features/queue.ts
+++ b/ytapp/src/features/queue.ts
@@ -68,6 +68,16 @@ export async function moveJob(from: number, to: number): Promise<void> {
   await invoke('queue_move', { from, to });
 }
 
+/** Export the current queue to a JSON file. */
+export async function exportQueue(path: string): Promise<void> {
+  await invoke('queue_export', { path });
+}
+
+/** Import queue items from a JSON file. */
+export async function importQueue(path: string, append = false): Promise<void> {
+  await invoke('queue_import', { path, append });
+}
+
 export async function listenProgress(onProgress: (p: QueueProgress) => void): Promise<() => void> {
   const unlisten = await listen<QueueProgress>('queue_progress', e => {
     if (e.payload) onProgress(e.payload as QueueProgress);

--- a/ytapp/tests/cli_queue_export.test.ts
+++ b/ytapp/tests/cli_queue_export.test.ts
@@ -1,0 +1,15 @@
+import assert from 'assert';
+const core = require('@tauri-apps/api/core');
+const events = require('@tauri-apps/api/event');
+
+(async () => {
+  let called = '';
+  let args: any;
+  core.invoke = async (cmd: string, a: any) => { called = cmd; args = a; };
+  events.listen = async () => () => {};
+  process.argv = ['node', 'cli.ts', 'queue-export', '/tmp/q.json'];
+  await import('../src/cli');
+  assert.strictEqual(called, 'queue_export');
+  assert.strictEqual(args.path, '/tmp/q.json');
+  console.log('cli queue-export test passed');
+})();

--- a/ytapp/tests/cli_queue_import.test.ts
+++ b/ytapp/tests/cli_queue_import.test.ts
@@ -1,0 +1,16 @@
+import assert from 'assert';
+const core = require('@tauri-apps/api/core');
+const events = require('@tauri-apps/api/event');
+
+(async () => {
+  let called = '';
+  let args: any;
+  core.invoke = async (cmd: string, a: any) => { called = cmd; args = a; };
+  events.listen = async () => () => {};
+  process.argv = ['node', 'cli.ts', 'queue-import', '/tmp/q.json', '--append'];
+  await import('../src/cli');
+  assert.strictEqual(called, 'queue_import');
+  assert.strictEqual(args.path, '/tmp/q.json');
+  assert.strictEqual(args.append, true);
+  console.log('cli queue-import test passed');
+})();


### PR DESCRIPTION
## Summary
- export and import job queue via backend API
- expose queue-export and queue-import commands
- document usage in README
- cover new CLI commands with tests

## Testing
- `ts-node --project ytapp/tsconfig.json scripts/generate-schema.ts`
- `cd ytapp && npm install`
- `cargo check` *(fails: glib-2.0 missing)*
- `npx ts-node src/cli.ts --help`
- `npx ts-node tests/csv.test.ts`
- `npx ts-node tests/upload.test.ts`
- `npx ts-node tests/cli_queue_export.test.ts`
- `npx ts-node tests/cli_queue_import.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_685f51c81cc48331a27172723dee025c