### PR TITLE
Add queue-add-batch CLI command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -425,6 +425,12 @@ Queue up a file for later processing:
 npx ts-node src/cli.ts queue-add input.wav --title "My Queued Video"
 ```
 
+Add multiple jobs at once from a CSV file or list of audio files:
+
+```bash
+npx ts-node src/cli.ts queue-add-batch a.wav b.wav --csv metadata.csv -d output
+```
+
 Show queued jobs:
 
 ```bash

--- a/ytapp/src/cli.ts
+++ b/ytapp/src/cli.ts
@@ -499,6 +499,92 @@ program
   });
 
 program
+  .command('queue-add-batch')
+  .description('Add multiple jobs to the processing queue')
+  .argument('[files...]', 'audio files')
+  .option('--csv <file>', 'CSV metadata file')
+  .option('-d, --output-dir <dir>', 'output directory', '.')
+  .option('--captions <srt>', 'captions file path')
+  .option('--font <font>', 'caption font')
+  .option('--font-path <path>', 'caption font file')
+  .option('--style <style>', 'caption font style')
+  .option('--size <size>', 'caption font size', (v) => parseInt(v, 10))
+  .option('--caption-color <color>', 'caption text color (hex)')
+  .option('--color <color>', 'alias for --caption-color')
+  .option('--caption-bg <color>', 'caption background color (hex)')
+  .option('--bg-color <color>', 'alias for --caption-bg')
+  .option('--position <pos>', 'caption position (top|center|bottom)')
+  .option('-b, --background <file>', 'background image or video')
+  .option('--watermark <file>', 'watermark image')
+  .option('--watermark-position <pos>', 'watermark position (top-left|top-right|bottom-left|bottom-right)')
+  .option('--watermark-opacity <n>', 'watermark opacity (0-1)', (v) => parseFloat(v))
+  .option('--watermark-scale <n>', 'watermark scale relative to width', (v) => parseFloat(v))
+  .option('--intro <file>', 'intro video or image')
+  .option('--outro <file>', 'outro video or image')
+  .option('--width <width>', 'output width', (v) => parseInt(v, 10))
+  .option('--height <height>', 'output height', (v) => parseInt(v, 10))
+  .option('--title <title>', 'video title')
+  .option('--description <desc>', 'video description')
+  .option('--tags <tags>', 'comma separated tags')
+  .option('--publish-at <date>', 'schedule publish date (ISO)')
+  .option('--thumbnail <file>', 'thumbnail image')
+  .option('-p, --profile <name>', 'load profile')
+  .action(async (files: string[], options: any) => {
+    try {
+      await verifyDependencies();
+      if (options.color && !options.captionColor) options.captionColor = options.color;
+      if (options.bgColor && !options.captionBg) options.captionBg = options.bgColor;
+
+      let csvMap: Record<string, CsvRow> = {};
+      if (options.csv) {
+        const rows = await parseCsv(options.csv);
+        csvMap = Object.fromEntries(rows.map(r => [r.file, r]));
+        if (!files.length) files = rows.map(r => r.file);
+      }
+
+      for (const file of files) {
+        const meta = csvMap[file] || {};
+        const merged = await mergeProfile(options.profile, {
+          captions: options.captions,
+          captionOptions: {
+            font: options.font,
+            fontPath: options.fontPath,
+            style: options.style,
+            size: options.size,
+            position: options.position,
+            color: options.captionColor,
+            background: options.captionBg,
+          },
+          background: options.background,
+          watermark: options.watermark,
+          watermarkPosition: options.watermarkPosition,
+          watermarkOpacity: options.watermarkOpacity,
+          watermarkScale: options.watermarkScale,
+          intro: options.intro,
+          outro: options.outro,
+          width: options.width,
+          height: options.height,
+          title: meta.title ?? options.title,
+          description: meta.description ?? options.description,
+          tags: meta.tags ?? (options.tags ? options.tags.split(',').map((t: string) => t.trim()).filter(Boolean) : undefined),
+          publishAt: meta.publishAt ?? options.publishAt,
+          thumbnail: options.thumbnail,
+        });
+        const params: GenerateParams = {
+          file,
+          output: path.join(options.outputDir, path.basename(file, path.extname(file)) + '.mp4'),
+          ...merged,
+        } as any;
+        const dest = path.join(options.outputDir, path.basename(file, path.extname(file)) + '.mp4');
+        await addJob({ GenerateUpload: { params, dest, thumbnail: options.thumbnail } } as any);
+      }
+    } catch (err) {
+      console.error('Error adding batch jobs:', err);
+      process.exitCode = 1;
+    }
+  });
+
+program
   .command('generate-upload-batch')
   .description('Generate multiple videos and upload to YouTube')
   .argument('[files...]', 'audio files')

--- a/ytapp/tests/cli_queue_add_batch.test.ts
+++ b/ytapp/tests/cli_queue_add_batch.test.ts
@@ -1,0 +1,20 @@
+import assert from 'assert';
+import fs from 'fs/promises';
+const core = require('@tauri-apps/api/core');
+const events = require('@tauri-apps/api/event');
+
+(async () => {
+  const csv = '/tmp/queue_batch.csv';
+  await fs.writeFile(csv, 'file,title\na.mp3,First\n');
+  const calls: any[] = [];
+  core.invoke = async (cmd: string, args: any) => {
+    if (cmd === 'queue_add') calls.push(args);
+  };
+  events.listen = async () => () => {};
+  process.argv = ['node', 'cli.ts', 'queue-add-batch', 'a.mp3', '--csv', csv, '-d', '/out'];
+  await import('../src/cli');
+  assert.strictEqual(calls.length, 1);
+  assert.strictEqual(calls[0].job.GenerateUpload.params.file, 'a.mp3');
+  assert.strictEqual(calls[0].job.GenerateUpload.dest, '/out/a.mp4');
+  console.log('cli queue-add-batch test passed');
+})();


### PR DESCRIPTION
## Summary
- implement `queue-add-batch` command to enqueue multiple jobs from files or CSV
- document new command in README
- generate updated schema
- add unit test for the new CLI

## Testing
- `TS_NODE_COMPILER_OPTIONS='{ "module": "commonjs" }' npx ts-node tests/csv.test.ts`
- `TS_NODE_COMPILER_OPTIONS='{ "module": "commonjs" }' npx ts-node tests/upload.test.ts`
- `npx ts-node src/cli.ts --help`
- `cargo check` *(fails: glib/gobject/gtk dev libraries missing)*

------
https://chatgpt.com/codex/tasks/task_e_685f56c910608331934203826c1e8e98