### PR TITLE
Add transcription cancel feature

### DIFF
--- a/ytapp/src/cli.ts
+++ b/ytapp/src/cli.ts
@@ -1024,6 +1024,18 @@ program
   });
 
 program
+  .command('transcribe-cancel')
+  .description('Cancel running transcription')
+  .action(async () => {
+    try {
+      await invoke('cancel_transcription');
+    } catch (err) {
+      console.error('Error canceling transcription:', err);
+      process.exitCode = 1;
+    }
+  });
+
+program
   .command('watch')
   .description('Watch directory for new audio files')
   .argument('<dir>', 'directory path')

--- a/ytapp/src/components/TranscribeButton.tsx
+++ b/ytapp/src/components/TranscribeButton.tsx
@@ -1,7 +1,7 @@
 // Button that transcribes audio to SRT and optionally translates it.
 import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { transcribeAudio } from '../features/transcription';
+import { transcribeAudio, cancelTranscription } from '../features/transcription';
 import { Language } from '../features/language';
 import { loadSettings } from '../features/settings';
 
@@ -40,11 +40,18 @@ const TranscribeButton: React.FC<TranscribeButtonProps> = ({ file, language, tar
         setRunning(false);
     };
 
+    const handleCancel = async () => {
+        await cancelTranscription();
+    };
+
     return (
         <div className="row">
             <button onClick={handleClick} disabled={running || !file}>
                 {running ? t('transcribing') : t('transcribe')}
             </button>
+            {running && (
+                <button onClick={handleCancel}>{t('cancel')}</button>
+            )}
             {error && <span>{error}</span>}
         </div>
     );

--- a/ytapp/src/features/transcription/index.ts
+++ b/ytapp/src/features/transcription/index.ts
@@ -48,3 +48,8 @@ export async function loadSrt(path: string): Promise<string> {
 export async function saveSrt(path: string, data: string): Promise<void> {
     await invoke('save_srt', { path, data });
 }
+
+/** Cancel the currently running transcription if any. */
+export async function cancelTranscription(): Promise<void> {
+    await invoke('cancel_transcription');
+}

--- a/ytapp/tests/cancel_transcription.test.ts
+++ b/ytapp/tests/cancel_transcription.test.ts
@@ -1,0 +1,30 @@
+import assert from 'assert';
+const core = require('@tauri-apps/api/core');
+const events = require('@tauri-apps/api/event');
+
+(async () => {
+  let cancelCalled = false;
+  let rejectFn: (() => void) | null = null;
+  core.invoke = async (cmd: string) => {
+    if (cmd === 'transcribe_audio') {
+      return new Promise((_r, rej) => { rejectFn = () => rej(new Error('canceled')); });
+    }
+    if (cmd === 'cancel_transcription') {
+      cancelCalled = true;
+      if (rejectFn) rejectFn();
+    }
+  };
+  let handler: any;
+  events.listen = async (name: string, h: (e: any) => void) => {
+    if (name === 'transcribe_canceled') handler = h;
+    return () => {};
+  };
+  const { transcribeAudio, cancelTranscription } = await import('../src/features/transcription');
+  const p = transcribeAudio({ file: 'a.mp3' }).catch(() => 'canceled');
+  await cancelTranscription();
+  if (handler) handler({});
+  const res = await p;
+  assert.strictEqual(res, 'canceled');
+  assert.ok(cancelCalled);
+  console.log('transcription cancel tests passed');
+})();

--- a/ytapp/tests/cli_transcribe_cancel.test.ts
+++ b/ytapp/tests/cli_transcribe_cancel.test.ts
@@ -1,0 +1,15 @@
+import assert from 'assert';
+const core = require('@tauri-apps/api/core');
+const events = require('@tauri-apps/api/event');
+
+(async () => {
+  let called = false;
+  core.invoke = async (cmd: string) => {
+    if (cmd === 'cancel_transcription') called = true;
+  };
+  events.listen = async () => () => {};
+  process.argv = ['node', 'cli.ts', 'transcribe-cancel'];
+  await import('../src/cli');
+  assert.ok(called);
+  console.log('cli transcribe-cancel test passed');
+})();


### PR DESCRIPTION
## Summary
- allow aborting whisper transcription
- add frontend helper and CLI command to cancel transcription
- show cancel button for transcription UI
- test cancelTranscription helper and CLI command

## Testing
- `npx -y ts-node --compiler-options '{"module":"CommonJS"}' scripts/generate-schema.ts`
- `cd ytapp && npm install`
- `cargo check` *(fails: gobject-2.0 not found)*
- `npx -y ts-node --compiler-options '{"module":"CommonJS"}' src/cli.ts --help`
- `npx -y ts-node --compiler-options '{"module":"CommonJS"}' ytapp/tests/run-all.ts` *(fails: AssertionError in cancel.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68604ca4b2ec8331a58eca22e2ed695c