### PR TITLE
Add recursive directory watch option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -290,7 +290,7 @@ dependencies and create `.env.tauri`. Then **source `.env.tauri`** (as noted in
 To automatically process files placed in a folder set the **Watch Directory**
 and enable **Auto Upload** in the settings page or use the CLI `watch` command.
 When the app starts it will immediately begin watching the configured folder using your saved settings.
-Run `npx ts-node src/cli.ts watch-stop` to disable watching again.
+Run `npx ts-node src/cli.ts watch-stop` to disable watching again. Use `--recursive` with the `watch` command to include subdirectories.
 
 ### Contribution
 
@@ -411,8 +411,9 @@ columns, where `tags` is a comma-separated list.
 Watch a directory and automatically process new audio files:
 
 ```bash
-npx ts-node src/cli.ts watch ./incoming --auto-upload
+npx ts-node src/cli.ts watch ./incoming --auto-upload --recursive
 ```
+Pass `--recursive` to process files in subdirectories as well.
 Stop watching:
 
 ```bash

--- a/ytapp/src-tauri/src/main.rs
+++ b/ytapp/src-tauri/src/main.rs
@@ -805,6 +805,7 @@ struct WatchDirectoryParams {
     dir: String,
     options: Option<WatchOptions>,
     auto_upload: bool,
+    recursive: Option<bool>,
 }
 
 #[command]
@@ -920,7 +921,12 @@ fn watch_directory(window: Window, params: WatchDirectoryParams) -> Result<(), S
         },
         Config::default(),
     ).map_err(|e| e.to_string())?;
-    watcher.watch(Path::new(&dir), RecursiveMode::NonRecursive).map_err(|e| e.to_string())?;
+    let mode = if params.recursive.unwrap_or(false) {
+        RecursiveMode::Recursive
+    } else {
+        RecursiveMode::NonRecursive
+    };
+    watcher.watch(Path::new(&dir), mode).map_err(|e| e.to_string())?;
     *guard = Some(watcher);
     Ok(())
 }

--- a/ytapp/src/cli.ts
+++ b/ytapp/src/cli.ts
@@ -1050,6 +1050,7 @@ program
   .option('--description <desc>', 'video description')
   .option('--tags <tags>', 'comma separated tags')
   .option('--publish-at <date>', 'schedule publish date (ISO)')
+  .option('--recursive', 'watch subdirectories')
   .option('--auto-upload', 'upload after generating')
   .action(async (dir: string, options: any) => {
     if (options.color && !options.captionColor) options.captionColor = options.color;
@@ -1079,6 +1080,7 @@ program
       description: options.description,
       tags: options.tags ? options.tags.split(',').map((t: string) => t.trim()).filter(Boolean) : undefined,
       publishAt: options.publishAt,
+      recursive: options.recursive,
       autoUpload: options.autoUpload,
     } as any);
   });

--- a/ytapp/src/features/watch.ts
+++ b/ytapp/src/features/watch.ts
@@ -5,8 +5,14 @@ import { GenerateParams } from './processing';
 export interface WatchParams extends Omit<GenerateParams, 'file' | 'output'> {
   autoUpload?: boolean;
   thumbnail?: string;
+  recursive?: boolean;
 }
 
 export async function watchDirectory(dir: string, options: WatchParams): Promise<void> {
-  await invoke('watch_directory', { dir, options, autoUpload: options.autoUpload });
+  await invoke('watch_directory', {
+    dir,
+    options,
+    autoUpload: options.autoUpload,
+    recursive: options.recursive,
+  });
 }

--- a/ytapp/tests/watch.test.ts
+++ b/ytapp/tests/watch.test.ts
@@ -43,3 +43,16 @@ const events = require('@tauri-apps/api/event');
   assert.strictEqual(args.options.autoUpload, false);
   console.log('cli watch-stop test passed');
 })();
+
+(async () => {
+  let args: any;
+  core.invoke = async (cmd: string, a: any) => {
+    if (cmd === 'watch_directory') args = a;
+  };
+  events.listen = async () => () => {};
+  process.argv = ['node', 'cli.ts', 'watch', '/tmp/in', '--recursive'];
+  await import('../src/cli');
+  assert.strictEqual(args.dir, '/tmp/in');
+  assert.strictEqual(args.recursive, true);
+  console.log('cli watch recursive flag passed');
+})();


### PR DESCRIPTION
## Summary
- allow recursive directory watching in Tauri backend
- expose new `recursive` flag in frontend helpers and CLI
- document CLI `--recursive` option
- test CLI flag forwarding

## Testing
- `npx -y ts-node scripts/generate-schema.ts`
- `cd ytapp && npm install`
- `cd src-tauri && cargo check`
- `cd .. && npx -y ts-node src/cli.ts --help`
- `npm test` *(fails: AssertionError in cli_is_signed_in_false.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68604ca46be08331bc092be902907d34