### PR TITLE
Update schema generation command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ its variables are available before running any checks.
 Run the following commands before committing changes:
 
 ```bash
-npx ts-node scripts/generate-schema.ts
+npx ts-node --project ytapp/tsconfig.json scripts/generate-schema.ts
 cd ytapp && npm install
 cd src-tauri && cargo check
 cd .. && npx ts-node src/cli.ts --help

--- a/docs/deep_dive.md
+++ b/docs/deep_dive.md
@@ -16,7 +16,7 @@ This document provides an overview of every major file and module in the reposit
 
 ### Top Level Files
 
-- **AGENTS.md** – Defines the required verification commands and overall guidelines. It instructs developers to run `scripts/generate-schema.ts`, `npm install`, `cargo check`, and `ts-node src/cli.ts --help` before committing. It also explains the devcontainer setup.
+- **AGENTS.md** – Defines the required verification commands and overall guidelines. It instructs developers to run `npx ts-node --project ytapp/tsconfig.json scripts/generate-schema.ts`, `npm install`, `cargo check`, and `ts-node src/cli.ts --help` before committing. It also explains the devcontainer setup.
 - **Makefile** – Implements the `verify`, `dev`, `test`, and `package` targets. `make verify` generates the shared schema then runs linting, TypeScript compilation, `cargo check`, and a CLI help check. The `test` target runs each TypeScript test sequentially; you can alternatively run `npm test` inside `ytapp`.
 - **readme.md** – Extensive implementation plan covering every feature: audio processing, transcription, YouTube integration, batch tools, UI design, packaging, setup and CLI usage.
 - **scripts/** – Contains bash and Node scripts used for setup, packaging and translation updates.

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ make dev                 # launches the Tauri app
 ```
 
 Before every commit run `make verify` (or the commands in `AGENTS.md`).
-This command first runs `scripts/generate-schema.ts` to keep TypeScript and Rust
+This command first runs `npx ts-node --project ytapp/tsconfig.json scripts/generate-schema.ts` to keep TypeScript and Rust
 schemas in sync before linting and compilation.
 If `cargo check` fails on Linux, run `scripts/install_tauri_deps.sh`.
 Run `make test` (or `npm test` inside `ytapp`) to run the automated tests.
@@ -267,7 +267,7 @@ The same setup steps are mirrored in `.codex/Dockerfile` which Codex uses as a
 bootstrap container.
 
 Before committing run `make verify` or the steps in `AGENTS.md`.
-`make verify` runs `scripts/generate-schema.ts` first, then lints and compiles:
+`make verify` runs `npx ts-node --project ytapp/tsconfig.json scripts/generate-schema.ts` first, then lints and compiles:
 ```bash
 make verify
 ```

--- a/ytapp/package.json
+++ b/ytapp/package.json
@@ -8,7 +8,7 @@
     "cli": "ts-node src/cli.ts",
     "lint": "tsc --noEmit",
     "a11y-test": "node scripts/a11y-test.js",
-    "test": "cd .. && ts-node scripts/generate-schema.ts && ts-node ytapp/tests/run-all.ts"
+    "test": "cd .. && ts-node --project ytapp/tsconfig.json scripts/generate-schema.ts && ts-node ytapp/tests/run-all.ts"
   },
   "dependencies": {
     "@tauri-apps/api": "^2.5.0",


### PR DESCRIPTION
## Summary
- update AGENTS instructions to use the tsconfig when generating the schema
- refresh docs to show the new command
- update test script with matching command

## Testing
- `yes | npx ts-node --project ytapp/tsconfig.json scripts/generate-schema.ts`
- `npm install` within `ytapp`
- `cargo check` *(fails: `gdk-3.0.pc` not found)*
- `npx ts-node src/cli.ts --help`


------
https://chatgpt.com/codex/tasks/task_e_6860597a77cc8331bf313c3472e6a796