### PR TITLE
Add queue summary command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -442,6 +442,11 @@ Show queued jobs:
 ```bash
 npx ts-node src/cli.ts queue-list
 ```
+Show a summary of queue statuses:
+
+```bash
+npx ts-node src/cli.ts queue-status
+```
 Remove a job by its index:
 ```bash
 npx ts-node src/cli.ts queue-remove 0

--- a/ytapp/src/cli.ts
+++ b/ytapp/src/cli.ts
@@ -11,7 +11,7 @@ import { translateSrt } from './utils/translate';
 import { parseCsv, CsvRow } from './utils/csv';
 import { watchDirectory } from './features/watch';
 import { generateBatchWithProgress } from './features/batch';
-import { addJob, listJobs, runQueue, clearQueue, clearFailed, clearFinished, removeJob, moveJob, pauseQueue, resumeQueue, exportQueue, importQueue } from './features/queue';
+import { addJob, listJobs, runQueue, clearQueue, clearFailed, clearFinished, removeJob, moveJob, pauseQueue, resumeQueue, exportQueue, importQueue, getQueueSummary } from './features/queue';
 import { listProfiles, getProfile, saveProfile, deleteProfile } from './features/profiles';
 import { listFonts } from './features/fonts';
 import { fetchPlaylists } from './features/youtube';
@@ -1119,6 +1119,19 @@ program
       console.log(JSON.stringify(jobs, null, 2));
     } catch (err) {
       console.error('Error listing queue:', err);
+      process.exitCode = 1;
+    }
+  });
+
+program
+  .command('queue-status')
+  .description('Show summary of queue jobs by status')
+  .action(async () => {
+    try {
+      const summary = await getQueueSummary();
+      console.log(JSON.stringify(summary, null, 2));
+    } catch (err) {
+      console.error('Error getting queue summary:', err);
       process.exitCode = 1;
     }
   });

--- a/ytapp/src/features/queue.ts
+++ b/ytapp/src/features/queue.ts
@@ -107,3 +107,22 @@ export async function listenNotify(onNotify: (n: QueueNotify) => void): Promise<
     unlisten();
   };
 }
+
+export interface QueueSummary {
+  pending: number;
+  running: number;
+  failed: number;
+  completed: number;
+}
+
+/**
+ * Return a summary of queue jobs by status.
+ */
+export async function getQueueSummary(): Promise<QueueSummary> {
+  const jobs = await listJobs();
+  const summary: QueueSummary = { pending: 0, running: 0, failed: 0, completed: 0 };
+  for (const job of jobs) {
+    summary[job.status]++;
+  }
+  return summary;
+}

--- a/ytapp/tests/cli_queue_status.test.ts
+++ b/ytapp/tests/cli_queue_status.test.ts
@@ -1,0 +1,22 @@
+import assert from 'assert';
+const core = require('@tauri-apps/api/core');
+const events = require('@tauri-apps/api/event');
+
+(async () => {
+  let invoked = false;
+  core.invoke = async (cmd: string) => {
+    if (cmd === 'queue_list') invoked = true;
+    return [
+      { job: {}, status: 'pending', retries: 0 },
+      { job: {}, status: 'completed', retries: 0 }
+    ];
+  };
+  events.listen = async () => () => {};
+  const logs: string[] = [];
+  console.log = (msg: string) => { logs.push(msg); };
+  process.argv = ['node', 'cli.ts', 'queue-status'];
+  await import('../src/cli');
+  assert.ok(invoked);
+  assert.ok(logs[0].includes('pending'));
+  console.log('cli queue-status test passed');
+})();

--- a/ytapp/tests/queue_status.test.ts
+++ b/ytapp/tests/queue_status.test.ts
@@ -1,0 +1,18 @@
+import assert from 'assert';
+const core = require('@tauri-apps/api/core');
+
+(async () => {
+  const q = [
+    { job: { Generate: { params: { file: 'a.mp3' }, dest: 'a.mp4' } }, status: 'pending', retries: 0 },
+    { job: { Generate: { params: { file: 'b.mp3' }, dest: 'b.mp4' } }, status: 'running', retries: 0 },
+    { job: { Generate: { params: { file: 'c.mp3' }, dest: 'c.mp4' } }, status: 'failed', retries: 1 },
+    { job: { Generate: { params: { file: 'd.mp3' }, dest: 'd.mp4' } }, status: 'completed', retries: 0 }
+  ];
+  core.invoke = async (cmd: string) => {
+    if (cmd === 'queue_list') return q;
+  };
+  const { getQueueSummary } = await import('../src/features/queue');
+  const summary = await getQueueSummary();
+  assert.deepStrictEqual(summary, { pending: 1, running: 1, failed: 1, completed: 1 });
+  console.log('queue status tests passed');
+})();


### PR DESCRIPTION
## Summary
- summarize queue with `getQueueSummary`
- expose summary via new `queue-status` CLI command
- document the command in README
- test queue status feature and CLI

## Testing
- `cargo check`
- `npx ts-node src/cli.ts --help`
- `npm test` *(fails: AssertionError in cancel.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68606bf81bbc8331b0f0260c3fc5b2f9