### PR TITLE
Add notification tests

### DIFF
--- a/ytapp/tests/notify.test.ts
+++ b/ytapp/tests/notify.test.ts
@@ -1,0 +1,35 @@
+import assert from 'assert';
+const notif = require('@tauri-apps/plugin-notification');
+
+(async () => {
+  let sent: any = undefined;
+  notif.isPermissionGranted = async () => true;
+  notif.requestPermission = async () => 'granted';
+  notif.sendNotification = (opts: any) => { sent = opts; };
+  (global as any).window = {};
+  const { notify } = await import('../src/utils/notify');
+  await notify('Title', 'Body');
+  assert.deepStrictEqual(sent, { title: 'Title', body: 'Body' });
+  console.log('notify via tauri passed');
+})();
+
+(async () => {
+  let sent = false;
+  let constructed: any = undefined;
+  notif.isPermissionGranted = async () => false;
+  notif.requestPermission = async () => 'denied';
+  notif.sendNotification = () => { sent = true; };
+  class FakeNotification {
+    static permission = 'granted';
+    static async requestPermission() { return 'granted'; }
+    constructor(public title: string, public opts: any) {
+      constructed = { title, opts };
+    }
+  }
+  (global as any).window = { Notification: FakeNotification };
+  const { notify } = await import('../src/utils/notify');
+  await notify('Title', 'Body');
+  assert.strictEqual(sent, false);
+  assert.deepStrictEqual(constructed, { title: 'Title', opts: { body: 'Body' } });
+  console.log('notify web fallback passed');
+})();

--- a/ytapp/tests/run-all.ts
+++ b/ytapp/tests/run-all.ts
@@ -2,7 +2,7 @@ import { readdirSync } from 'fs';
 import path from 'path';
 
 (async () => {
-  const files = readdirSync(__dirname)
+  const files = [...new Set([...readdirSync(__dirname), 'notify.test.ts'])]
     .filter(f => f.endsWith('.test.ts'))
     .sort();
   for (const f of files) {


### PR DESCRIPTION
## Summary
- add unit tests for notification utility
- ensure `run-all.ts` explicitly includes new test

## Testing
- `npx ts-node --project ytapp/tsconfig.json scripts/generate-schema.ts`
- `cd ytapp && npm install`
- `cd src-tauri && cargo check`
- `cd .. && npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_68606bfad0c8833194b1a516cf1efd63