### PR TITLE
Add CLI cancel command tests

### DIFF
--- a/ytapp/tests/cli_generate_cancel.test.ts
+++ b/ytapp/tests/cli_generate_cancel.test.ts
@@ -1,0 +1,13 @@
+import assert from 'assert';
+const core = require('@tauri-apps/api/core');
+const events = require('@tauri-apps/api/event');
+
+(async () => {
+  let called = false;
+  core.invoke = async (cmd: string) => { if (cmd === 'cancel_generate') called = true; };
+  events.listen = async () => () => {};
+  process.argv = ['node', 'cli.ts', 'generate-cancel'];
+  await import('../src/cli');
+  assert.ok(called);
+  console.log('cli generate-cancel test passed');
+})();

--- a/ytapp/tests/cli_upload_cancel.test.ts
+++ b/ytapp/tests/cli_upload_cancel.test.ts
@@ -1,0 +1,13 @@
+import assert from 'assert';
+const core = require('@tauri-apps/api/core');
+const events = require('@tauri-apps/api/event');
+
+(async () => {
+  let called = false;
+  core.invoke = async (cmd: string) => { if (cmd === 'cancel_upload') called = true; };
+  events.listen = async () => () => {};
+  process.argv = ['node', 'cli.ts', 'upload-cancel'];
+  await import('../src/cli');
+  assert.ok(called);
+  console.log('cli upload-cancel test passed');
+})();

--- a/ytapp/tests/run-all.ts
+++ b/ytapp/tests/run-all.ts
@@ -2,7 +2,12 @@ import { readdirSync } from 'fs';
 import path from 'path';
 
 (async () => {
-  const files = [...new Set([...readdirSync(__dirname), 'notify.test.ts'])]
+  const files = [...new Set([
+    ...readdirSync(__dirname),
+    'notify.test.ts',
+    'cli_generate_cancel.test.ts',
+    'cli_upload_cancel.test.ts',
+  ])]
     .filter(f => f.endsWith('.test.ts'))
     .sort();
   for (const f of files) {


### PR DESCRIPTION
## Summary
- add tests for generate-cancel and upload-cancel CLI commands
- ensure new tests are run by the custom test runner

## Testing
- `npx -y ts-node --project ytapp/tsconfig.json scripts/generate-schema.ts`
- `cd ytapp && npm install`
- `cd src-tauri && cargo check` *(fails: `glib-2.0` not found)*
- `cd .. && npx -y ts-node src/cli.ts --help`
- `npx -y ts-node ytapp/tests/run-all.ts` *(fails: unknown command 'generate-cancel')*

------
https://chatgpt.com/codex/tasks/task_e_68607fe047708331a78a7dd485e22e0b