### PR TITLE
Improve setup_codex.sh error handling

### DIFF
--- a/scripts/setup_codex.sh
+++ b/scripts/setup_codex.sh
@@ -2,10 +2,19 @@
 set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-"$ROOT_DIR/scripts/setup.sh"
+if [ -z "${SKIP_DEPS:-}" ]; then
+  if [[ "$(uname -s)" == "Linux" ]] && ! command -v sudo >/dev/null; then
+    echo "Error: sudo is required to install system packages. Set SKIP_DEPS=1 to skip." >&2
+    exit 1
+  fi
 
-if [[ "$(uname -s)" == "Linux" ]]; then
-  "$ROOT_DIR/scripts/install_tauri_deps.sh"
+  "$ROOT_DIR/scripts/setup.sh"
+
+  if [[ "$(uname -s)" == "Linux" ]]; then
+    "$ROOT_DIR/scripts/install_tauri_deps.sh"
+  fi
+else
+  echo "SKIP_DEPS set; skipping system package installation" >&2
 fi
 
 if [ -f "$ROOT_DIR/.env.tauri" ]; then


### PR DESCRIPTION
## Summary
- improve Linux setup logic to fail fast if sudo is unavailable
- allow skipping dependency installation via `SKIP_DEPS`

## Testing
- `npx -y ts-node --project ytapp/tsconfig.json scripts/generate-schema.ts`
- `cd ytapp && npm install`
- `cargo check` *(fails: `glib-2.0` not found)*
- `npx -y ts-node src/cli.ts --help`


------
https://chatgpt.com/codex/tasks/task_e_68607fde3fa483318be6394a3aea09ef