### PR TITLE
Add CLI cancel commands

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -403,6 +403,13 @@ npx ts-node src/cli.ts generate-batch a.wav b.wav -d ./out --title "Batch Title"
 During uploads the CLI prints progress percentages similar to video generation.
 Press `Ctrl-C` at any time to cancel the current operation.
 
+Cancel generation or upload from another terminal:
+
+```bash
+npx ts-node src/cli.ts generate-cancel
+npx ts-node src/cli.ts upload-cancel
+```
+
 `--caption-color` and `--caption-bg` accept hex colors. You may also use the
 shorter `--color` and `--bg-color` aliases.
 `--watermark` adds an overlay image. Use `--watermark-position` to place it in

--- a/ytapp/src/cli.ts
+++ b/ytapp/src/cli.ts
@@ -1036,6 +1036,30 @@ program
   });
 
 program
+  .command('generate-cancel')
+  .description('Cancel running video generation')
+  .action(async () => {
+    try {
+      await invoke('cancel_generate');
+    } catch (err) {
+      console.error('Error canceling generation:', err);
+      process.exitCode = 1;
+    }
+  });
+
+program
+  .command('upload-cancel')
+  .description('Cancel running upload')
+  .action(async () => {
+    try {
+      await invoke('cancel_upload');
+    } catch (err) {
+      console.error('Error canceling upload:', err);
+      process.exitCode = 1;
+    }
+  });
+
+program
   .command('watch')
   .description('Watch directory for new audio files')
   .argument('<dir>', 'directory path')


### PR DESCRIPTION
## Summary
- add `generate-cancel` and `upload-cancel` commands to the CLI
- document these new commands in the README

## Testing
- `npx --yes ts-node --project ytapp/tsconfig.json scripts/generate-schema.ts`
- `cd ytapp && npm install`
- `cd src-tauri && cargo check`
- `cd .. && npx --yes ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_68607fd9db048331b79952df02b6e583