### PR TITLE
Fix devcontainer image references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 These guidelines apply to the entire repository.
 
 ## Devcontainer
-A pre-built development container image exists for this project: `ghcr.io/<OWNER>/ytapp-dev:latest`. Codex should
+A pre-built development container image exists for this project: `ghcr.io/letapicode/ytapp-dev:latest`. Codex should
 start from this image (or run `devcontainer open` if supported) before executing
 `make verify`. Environment initialization is handled by `scripts/setup_codex.sh`
 (invoked automatically via `.codex/bootstrap.sh`). This script installs Tauri

--- a/docs/SELF_REFLECTION.md
+++ b/docs/SELF_REFLECTION.md
@@ -31,7 +31,7 @@ This document summarizes how the Codex agent operates and how it should be guide
 - The agent runs in an isolated container without internet access unless explicitly enabled by the user.
 - If required dependencies are missing, commands or tests may fail. The agent should report such issues and may include a disclaimer about environment limitations in the PR.
 
-Codex tasks should start from the prebuilt image `ghcr.io/<OWNER>/ytapp-dev:latest`, which is built from `.codex/Dockerfile`. This container already includes all dependencies and runs `.codex/bootstrap.sh` on launch, ensuring `scripts/setup.sh` and `.env.tauri` are applied automatically. Using this image removes most initialization overhead.
+Codex tasks should start from the prebuilt image `ghcr.io/letapicode/ytapp-dev:latest`, which is built from `.codex/Dockerfile`. This container already includes all dependencies and runs `.codex/bootstrap.sh` on launch, ensuring `scripts/setup.sh` and `.env.tauri` are applied automatically. Using this image removes most initialization overhead.
 
 ## 🛠️ The Codex Journey: What Really Happens Behind the Scenes
 

--- a/readme.md
+++ b/readme.md
@@ -265,7 +265,7 @@ packages and writes `.env.tauri`:
 * Windows (PowerShell): `scripts/install_tauri_deps_windows.ps1`
 
 You may also use the provided devcontainer which automatically executes the setup script (`scripts/setup_codex.sh`) when first created.
-Codex and all contributors should open the repo using the prebuilt image `ghcr.io/<OWNER>/ytapp-dev:latest` for the fastest startup.
+Codex and all contributors should open the repo using the prebuilt image `ghcr.io/letapicode/ytapp-dev:latest` for the fastest startup.
 The same setup steps are mirrored in `.codex/Dockerfile` which Codex uses as a
 bootstrap container.
 
@@ -279,7 +279,7 @@ The CI pipeline runs the same command using the devcontainer image.
 
 ### Codex Container
 
-`.codex/config.yaml` lists the verification steps Codex runs and references `.codex/bootstrap.sh` for initialization. The development container is built from `.codex/Dockerfile` and published as `ghcr.io/<OWNER>/ytapp-dev:latest`. Starting from this prebuilt image allows Codex to skip dependency installation; the bootstrap script runs `scripts/setup.sh` and sources `.env.tauri` so the environment is ready immediately. See [docs/SELF_REFLECTION.md](docs/SELF_REFLECTION.md) for more details on Codex operations.
+`.codex/config.yaml` lists the verification steps Codex runs and references `.codex/bootstrap.sh` for initialization. The development container is built from `.codex/Dockerfile` and published as `ghcr.io/letapicode/ytapp-dev:latest`. Starting from this prebuilt image allows Codex to skip dependency installation; the bootstrap script runs `scripts/setup.sh` and sources `.env.tauri` so the environment is ready immediately. See [docs/SELF_REFLECTION.md](docs/SELF_REFLECTION.md) for more details on Codex operations.
 
 ### Troubleshooting
 


### PR DESCRIPTION
## Summary
- update devcontainer image references to use real repository owner

## Testing
- `npx ts-node --project ytapp/tsconfig.json scripts/generate-schema.ts`
- `cd ytapp && npm install`
- `cd src-tauri && cargo check`
- `cd .. && npx ts-node src/cli.ts --help`


------
https://chatgpt.com/codex/tasks/task_e_68607fd7d48883318055f14f46a29069