### PR TITLE
Add tests for encrypted token storage

### DIFF
--- a/ytapp/src-tauri/Cargo.toml
+++ b/ytapp/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@ build = "build.rs"
 license = "MIT"
 
 [dependencies]
-tauri = { version = "=1.8.3", features = ["dialog", "updater"] }
+tauri = { version = "=1.8.3", features = ["dialog", "updater", "test"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 whisper_cli = "0.1.5"

--- a/ytapp/src-tauri/src/job_queue.rs
+++ b/ytapp/src-tauri/src/job_queue.rs
@@ -235,13 +235,16 @@ pub fn import_queue(app: &tauri::AppHandle, path: &str, append: bool) -> Result<
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tauri::test::mock_app;
+    use tauri::test::{mock_context, noop_assets};
+    use tauri::Builder;
 
     #[test]
     fn persist_and_retry() {
         let dir = tempfile::tempdir().unwrap();
         std::env::set_var("YTAPP_TEST_DIR", dir.path());
-        let app = mock_app();
+        let app = Builder::default()
+            .build(mock_context(noop_assets()))
+            .unwrap();
         let params = GenerateParams { file: "a.mp3".into(), output: None, captions: None, caption_options: None, background: None, intro: None, outro: None, watermark: None, watermark_position: None, watermark_opacity: None, watermark_scale: None, width: None, height: None, title: None, description: None, tags: None, publish_at: None, thumbnail: None, privacy: None, playlist_id: None };
         enqueue(&app.handle(), Job::Generate { params: params.clone(), dest: "a.mp4".into() }).unwrap();
         load_queue(&app.handle()).unwrap();
@@ -257,7 +260,9 @@ mod tests {
     fn clear_failed_only_removes_failed_jobs() {
         let dir = tempfile::tempdir().unwrap();
         std::env::set_var("YTAPP_TEST_DIR", dir.path());
-        let app = mock_app();
+        let app = Builder::default()
+            .build(mock_context(noop_assets()))
+            .unwrap();
         let params = GenerateParams { file: "a.mp3".into(), output: None, captions: None, caption_options: None, background: None, intro: None, outro: None, watermark: None, watermark_position: None, watermark_opacity: None, watermark_scale: None, width: None, height: None, title: None, description: None, tags: None, publish_at: None, thumbnail: None, privacy: None, playlist_id: None };
         enqueue(&app.handle(), Job::Generate { params: params.clone(), dest: "a.mp4".into() }).unwrap();
         enqueue(&app.handle(), Job::Generate { params: params.clone(), dest: "b.mp4".into() }).unwrap();
@@ -275,7 +280,9 @@ mod tests {
     fn export_and_import() {
         let dir = tempfile::tempdir().unwrap();
         std::env::set_var("YTAPP_TEST_DIR", dir.path());
-        let app = mock_app();
+        let app = Builder::default()
+            .build(mock_context(noop_assets()))
+            .unwrap();
         let params = GenerateParams { file: "a.mp3".into(), output: None, captions: None, caption_options: None, background: None, intro: None, outro: None, watermark: None, watermark_position: None, watermark_opacity: None, watermark_scale: None, width: None, height: None, title: None, description: None, tags: None, publish_at: None, thumbnail: None, privacy: None, playlist_id: None };
         enqueue(&app.handle(), Job::Generate { params: params.clone(), dest: "a.mp4".into() }).unwrap();
         let export_path = dir.path().join("q.json");

--- a/ytapp/src-tauri/src/token_store.rs
+++ b/ytapp/src-tauri/src/token_store.rs
@@ -1,10 +1,13 @@
+use anyhow::{Context, Result};
+use chacha20poly1305::{
+    aead::{Aead, KeyInit, OsRng},
+    Key, XChaCha20Poly1305, XNonce,
+};
+use rand_core::RngCore;
+use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, path::PathBuf};
 use tokio::sync::Mutex;
-use serde::{Serialize, Deserialize};
-use yup_oauth2::storage::{TokenStorage, TokenInfo};
-use anyhow::{Context, Result};
-use chacha20poly1305::{aead::{Aead, KeyInit, OsRng}, XChaCha20Poly1305, Key, XNonce};
-use rand_core::RngCore;
+use yup_oauth2::storage::{TokenInfo, TokenStorage};
 
 #[derive(Serialize, Deserialize, Default)]
 struct StoredTokens(HashMap<String, TokenInfo>);
@@ -35,7 +38,11 @@ impl EncryptedTokenStorage {
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => StoredTokens::default(),
             Err(e) => return Err(e.into()),
         };
-        Ok(Self { path, key, tokens: Mutex::new(tokens) })
+        Ok(Self {
+            path,
+            key,
+            tokens: Mutex::new(tokens),
+        })
     }
 
     async fn write(&self) -> Result<()> {
@@ -75,5 +82,59 @@ impl TokenStorage for EncryptedTokenStorage {
     async fn get(&self, scopes: &[&str]) -> Option<TokenInfo> {
         let lock = self.tokens.lock().await;
         lock.0.get(&Self::key_for(scopes)).cloned()
+    }
+}
+
+#[cfg(test)]
+mod token_store_tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn store_and_retrieve_token() {
+        tauri::async_runtime::block_on(async {
+            let dir = tempdir().unwrap();
+            let path = dir.path().join("tokens.bin");
+            let key = [1u8; 32];
+
+            let storage = EncryptedTokenStorage::new(&path, key).await.unwrap();
+            let token = TokenInfo {
+                access_token: Some("access".into()),
+                refresh_token: Some("refresh".into()),
+                expires_at: None,
+                id_token: None,
+            };
+
+            storage.set(&["a", "b"], token.clone()).await.unwrap();
+
+            let retrieved = storage.get(&["b", "a"]).await;
+            assert_eq!(retrieved, Some(token));
+        });
+    }
+
+    #[test]
+    fn fails_with_wrong_key() {
+        tauri::async_runtime::block_on(async {
+            let dir = tempdir().unwrap();
+            let path = dir.path().join("tokens.bin");
+            let correct_key = [2u8; 32];
+
+            let storage = EncryptedTokenStorage::new(&path, correct_key)
+                .await
+                .unwrap();
+            let token = TokenInfo {
+                access_token: Some("t".into()),
+                refresh_token: None,
+                expires_at: None,
+                id_token: None,
+            };
+            storage.set(&["s"], token).await.unwrap();
+
+            drop(storage);
+
+            let wrong_key = [3u8; 32];
+            let result = EncryptedTokenStorage::new(&path, wrong_key).await;
+            assert!(result.is_err());
+        });
     }
 }


### PR DESCRIPTION
## Summary
- enable `test` feature for tauri so mock helpers work
- create integration tests for `EncryptedTokenStorage`
- update existing queue tests to build a Wry runtime app for compatibility

## Testing
- `npx -y ts-node --project ytapp/tsconfig.json scripts/generate-schema.ts`
- `npm install` in `ytapp`
- `cargo check` in `ytapp/src-tauri`
- `npx -y ts-node src/cli.ts --help` in `ytapp`
- `cargo test` *(fails: linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_6861b9fb76708331970be814126098ed