### PR TITLE
Update readme with Argos Translate dependency

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -249,6 +249,11 @@ The application automatically verifies that FFmpeg and Whisper are installed at
 startup. To run this check manually use:
 `npx ts-node src/cli.ts check-deps`
 
+For subtitle translation **Argos Translate** must also be available in your
+`PATH`. Verify installation with:
+`argos-translate --version`
+See <https://www.argosopentech.com/> for download instructions.
+
 ```bash
 git clone https://github.com/letapicode/YoutubeAutomation.git
 cd YoutubeAutomation


### PR DESCRIPTION
## Summary
- mention Argos Translate under Setup so users know the subtitle translator must be installed

## Testing
- `npx ts-node --project ytapp/tsconfig.json scripts/generate-schema.ts`
- `cd ytapp && npm install`
- `cd src-tauri && cargo check`
- `cd .. && npx ts-node src/cli.ts --help`


------
https://chatgpt.com/codex/tasks/task_e_6861b9fa47a8833181e054dceaf11b63