### PR TITLE
Handle canceled events in generator

### DIFF
--- a/ytapp/tests/cancel.test.ts
+++ b/ytapp/tests/cancel.test.ts
@@ -4,14 +4,12 @@ const events = require('@tauri-apps/api/event');
 
 (async () => {
   let cancelCalled = false;
-  let rejectGen: (() => void) | null = null;
   core.invoke = async (cmd: string) => {
     if (cmd === 'generate_video') {
-      return new Promise((_r, rej) => { rejectGen = () => rej(new Error('canceled')); });
+      return new Promise(() => {});
     }
     if (cmd === 'cancel_generate') {
       cancelCalled = true;
-      if (rejectGen) rejectGen();
     }
   };
   let handler: any;


### PR DESCRIPTION
## Summary
- reject `generateVideo` when a `generate_canceled` event occurs
- update unit test to match cancel logic

## Testing
- `npx ts-node --project ytapp/tsconfig.json scripts/generate-schema.ts`
- `cd ytapp && npm install`
- `cd src-tauri && cargo check` *(failed: glib-2.0 not found)*
- `cd .. && npx ts-node src/cli.ts --help`
- `npm test` *(fails: AssertionError in cli_is_signed_in_false.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6861d53beec483318d01b074a5cc709f