### PR TITLE
Add translation failure test

### DIFF
--- a/ytapp/tests/translate.test.ts
+++ b/ytapp/tests/translate.test.ts
@@ -22,3 +22,30 @@ const child = require('child_process');
   assert.ok(called);
   console.log('translate tests passed');
 })();
+
+(async () => {
+  let called = false;
+  child.spawn = (cmd: string, args: string[]) => {
+    called = true;
+    assert.strictEqual(cmd, 'argos-translate');
+    const idx = args.indexOf('--from-lang');
+    assert.ok(idx >= 0);
+    assert.strictEqual(args[idx + 1], 'fr');
+    return {
+      on: (ev: string, cb: (code: number) => void) => {
+        if (ev === 'exit') setTimeout(() => cb(1), 0);
+      },
+    } as any;
+  };
+
+  let err: Error | null = null;
+  try {
+    await translateSrt('/tmp/test.srt', 'es', 'fr');
+  } catch (e) {
+    err = e as Error;
+  }
+  assert.ok(err instanceof Error);
+  assert.strictEqual(err?.message, 'translation failed');
+  assert.ok(called);
+  console.log('translate failure tests passed');
+})();


### PR DESCRIPTION
## Summary
- extend translate.test.ts with failure scenario

## Testing
- `npx ts-node --project ytapp/tsconfig.json scripts/generate-schema.ts`
- `cd ytapp && npm install`
- `cd src-tauri && cargo check`
- `cd .. && npx ts-node src/cli.ts --help`


------
https://chatgpt.com/codex/tasks/task_e_6861e5813ea483318526fded14d57515