### PR TITLE
Add ignore patterns for node and Tauri build dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 
 .env
 dist/
+node_modules/
+ytapp/src-tauri/target/
+ytapp/dist/


### PR DESCRIPTION
## Summary
- update repo `.gitignore` to ignore `node_modules/`, Tauri `target/` and built dist

## Testing
- `npx --yes ts-node --project ytapp/tsconfig.json scripts/generate-schema.ts`
- `npm install` in `ytapp`
- `cargo check` in `ytapp/src-tauri`
- `npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_6861e57f43a083319d6cb941320d0440