### PR TITLE
Fix README openssl command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -152,7 +152,7 @@ Run `make test` (or `npm test` inside `ytapp`) to run the automated tests.
   * Tokens stored in the file from `YOUTUBE_TOKEN_FILE` (defaults to
     `youtube_tokens.enc`)
   * Encryption key provided via `YOUTUBE_TOKEN_KEY` which must be **32 bytes**.
-    Generate with `openssl rand -hex 16` and export it before running the app
+    Generate with `openssl rand -hex 32` and export it before running the app
 * Publish dates entered in the UI use your local time zone and are converted to UTC on upload
 * Batch upload support
 


### PR DESCRIPTION
## Summary
- fix the example command for generating a 32-byte encryption key

## Testing
- `npx -y ts-node --project ytapp/tsconfig.json scripts/generate-schema.ts`
- `npm install` within `ytapp`
- `cargo check` *(fails: `glib-2.0` required by `glib-sys` not found)*
- `npx -y ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_6861ff8a2a808331b30fa3b96d4a5d58