### PR TITLE
Fix test target exit codes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,8 @@ dev:
 test:
 	$(TS_NODE) --project ytapp/tsconfig.json scripts/generate-schema.ts
 	cd ytapp && npx tsc --noEmit
-	for f in ytapp/tests/*.ts; do $(TS_NODE) "$f" || true; done
-	cd ytapp/src-tauri && cargo test --all-targets || true
+	fail=0; for f in ytapp/tests/*.ts; do $(TS_NODE) "$$f" || fail=1; done; [ $$fail -eq 0 ]
+	cd ytapp/src-tauri && cargo test --all-targets
 
 package:
 	./scripts/package.sh


### PR DESCRIPTION
## Summary
- fail `make test` when any TypeScript or Rust test fails
- keep Makefile indented with tabs

## Testing
- `make test` *(fails: AssertionError - expected values to be strictly equal)*

------
https://chatgpt.com/codex/tasks/task_e_6861ff8f7cbc8331b0df9cd7f7342bf7