### PR TITLE
Add parse_publish_at unit tests

### DIFF
--- a/ytapp/src-tauri/src/main.rs
+++ b/ytapp/src-tauri/src/main.rs
@@ -1504,6 +1504,7 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::prelude::*;
 
     #[test]
     fn load_and_save_srt() {
@@ -1583,5 +1584,25 @@ mod tests {
     fn deps_script_windows() {
         let path = tauri_deps_script_path().unwrap();
         assert!(path.ends_with("scripts/install_tauri_deps_windows.ps1"));
+    }
+
+    #[test]
+    fn parse_publish_at_rfc3339() {
+        let dt = parse_publish_at("2023-05-15T10:00:00Z").unwrap();
+        let expected = Utc.with_ymd_and_hms(2023, 5, 15, 10, 0, 0).unwrap();
+        assert_eq!(dt, expected);
+    }
+
+    #[test]
+    fn parse_publish_at_local() {
+        std::env::set_var("TZ", "UTC");
+        let dt = parse_publish_at("2023-05-15T10:00").unwrap();
+        let expected = Utc.with_ymd_and_hms(2023, 5, 15, 10, 0, 0).unwrap();
+        assert_eq!(dt, expected);
+    }
+
+    #[test]
+    fn parse_publish_at_invalid() {
+        assert!(parse_publish_at("not a date").is_none());
     }
 }


### PR DESCRIPTION
## Summary
- add missing chrono import
- test parse_publish_at for RFC3339 and local datetime formats
- test invalid datetime parsing

## Testing
- `npx ts-node --project ytapp/tsconfig.json scripts/generate-schema.ts` *(fails: canceled)*
- `cd ytapp && npm install`
- `cd src-tauri && cargo check` *(fails: could not compile `ytapp`)*
- `cd .. && npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_6862b5bc3a9483319a41f45085e37d1f