### PR TITLE
Update docs for GTK deps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,13 @@ cd .. && npx ts-node src/cli.ts --help
 Install `ts-node` globally with `npm install -g ts-node` or ensure `npx` can
 download it to run the CLI checks and examples.
 
-`cargo check` may require system packages. Run the appropriate install script
-for your OS (`./scripts/install_tauri_deps.sh`, `./scripts/install_tauri_deps_macos.sh` or `./scripts/install_tauri_deps_windows.ps1`) if needed.
+`cargo check` may require GTK/WebKit development packages like `glib-2.0`. Run
+the appropriate install script for your OS
+(`./scripts/install_tauri_deps.sh`, `./scripts/install_tauri_deps_macos.sh` or
+`./scripts/install_tauri_deps_windows.ps1`) or manually install packages such
+as `libgtk-3-dev`, `libglib2.0-dev`, `libsoup2.4-dev`,
+`libwebkit2gtk-4.1-dev` and `libjavascriptcoregtk-4.1-dev` if you encounter a
+`glib-2.0.pc` not found error.
 Be sure `.env.tauri` from `scripts/setup_codex.sh` is sourced (or export the
 `PKG_CONFIG_PATH` it contains) before running cargo.
 

--- a/docs/deep_dive.md
+++ b/docs/deep_dive.md
@@ -22,7 +22,10 @@ This document provides an overview of every major file and module in the reposit
 - **scripts/** – Contains bash and Node scripts used for setup, packaging and translation updates.
   - `setup.sh` installs toolchains and dependencies.
   - `setup_codex.sh` runs `setup.sh` and installs system packages on Linux.
-  - `install_tauri_deps.sh` installs GTK/WebKit headers and writes `.env.tauri` with `PKG_CONFIG_PATH`.
+  - `install_tauri_deps.sh` installs GTK/WebKit headers such as `libgtk-3-dev`,
+    `libglib2.0-dev`, `libsoup2.4-dev`, `libwebkit2gtk-4.1-dev` and
+    `libjavascriptcoregtk-4.1-dev` then writes `.env.tauri` with
+    `PKG_CONFIG_PATH`.
   - `generate-schema.ts` generates TypeScript and Rust schema files from a common definition.
 
 ## Documentation (`docs/`)
@@ -108,7 +111,7 @@ While a job runs, the generation and upload functions emit `queue_progress` even
 
 ## Next Steps for Contributors
 
-1. **Set up the environment** using `scripts/setup_codex.sh` or the devcontainer image. Source `.env.tauri` before running Rust commands.
+1. **Set up the environment** using `scripts/setup_codex.sh` or the devcontainer image. Source `.env.tauri` before running Rust commands. If `cargo check` complains about a missing `glib-2.0.pc`, run `scripts/install_tauri_deps.sh` (or install `libgtk-3-dev libglib2.0-dev libsoup2.4-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev`) and retry.
 2. **Run `make verify`** (or the individual commands in `AGENTS.md`) to generate the shared schema and ensure TypeScript, Rust and CLI checks pass.
 3. **Frontend changes** should go in `ytapp/src` – React components or feature modules. Keep indentation consistent (2 spaces for `.ts`, 4 for `.tsx`).
 4. **Backend changes** belong under `ytapp/src-tauri/src`. Add new Tauri commands here and expose them through small wrappers under `src/features`.


### PR DESCRIPTION
## Summary
- document GTK/WebKit packages required for `cargo check`
- show `install_tauri_deps.sh` installs those packages
- mention how to fix missing `glib-2.0.pc` errors

## Testing
- `npx --yes ts-node --project ytapp/tsconfig.json scripts/generate-schema.ts`
- `npm install` within `ytapp`
- `cargo check` in `ytapp/src-tauri`
- `npx --yes ts-node src/cli.ts --help`


------
https://chatgpt.com/codex/tasks/task_e_6862cdd25ec08331b24aa430b85fca53