### PR TITLE
docs: fix merge conflict guide link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,6 @@ This folder summarizes the key documents found in the repository.
 - **[SELF_REFLECTION.md](../SELF_REFLECTION.md)** – Notes on how the Codex agent operates within this repository.
 - **[prompt.md](../prompt.md)** – Original prompt that sparked development of the application.
 - **[prompttracking.md](../prompttracking.md)** – History of major prompt updates.
-- **[pullrequest_merge_conflict.md](../pullrequest_merge_conflict.md)** – Guide for resolving PR merge conflicts.
+- **[merge_conflict.md](../docs/merge_conflict.md)** – Guide for resolving PR merge conflicts.
 - **[design/wireframes/README.md](../design/wireframes/README.md)** – Basic ASCII diagrams of the current UI flow.
 

--- a/docs/merge_conflict.md
+++ b/docs/merge_conflict.md
@@ -60,7 +60,7 @@ locally, run `git merge-base` or `git status` to detect conflicts.
 
 The repository occasionally receives a giant PR that contains all tasks at once, along with individual PRs for each task. The giant PR usually merges first because it covers everything at once. However, the smaller PRs are still useful to check for missed functionality.
 
-### `pullrequest_merge_conflict.md`
+### `merge_conflict.md`
 
 #### \ud83d\udccc Purpose
 


### PR DESCRIPTION
## Summary
- fix link to merge conflict guide
- update heading text in merge_conflict.md

## Testing
- `./ytapp/node_modules/.bin/ts-node --project ytapp/tsconfig.json scripts/generate-schema.ts`
- `cd ytapp && npm install`
- `cd src-tauri && cargo check`
- `cd .. && npx ts-node src/cli.ts --help`


------
https://chatgpt.com/codex/tasks/task_e_6862ced120ec8331ad7343aaef647c3c