### PR TITLE
Update Windows setup script to use Tauri CLI

### DIFF
--- a/scripts/setup_windows.ps1
+++ b/scripts/setup_windows.ps1
@@ -324,7 +324,7 @@ function Build-Project {
         }
 
         Write-Info "Running build..."
-        npm run tauri build
+        npx tauri build
 
         $buildSuccess = $LASTEXITCODE -eq 0
 
@@ -525,7 +525,7 @@ if ($allToolsInstalled) {
         Write-Host "`nDependencies were installed, but the project build failed." -ForegroundColor Yellow
         Write-Host "You can try building manually with:" -ForegroundColor Yellow
         Write-Host "  cd ytapp" -ForegroundColor Yellow
-        Write-Host "  npm run tauri build" -ForegroundColor Yellow
+        Write-Host "  npx tauri build" -ForegroundColor Yellow
         exit 1
     }
 } else {


### PR DESCRIPTION
## Summary
- call `npx tauri build` directly in the `Build-Project` function
- update the fallback instructions accordingly

## Testing
- `npx ts-node --project ytapp/tsconfig.json scripts/generate-schema.ts` *(fails: requires interactive install)*
- `cd ytapp && npm install`
- `cd src-tauri && cargo check` *(fails: `glib-2.0.pc` not found)*
- `cd .. && npx ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_68718bf07bec8331b1725a53e4d2d70e