### PR TITLE
Update Windows build command

### DIFF
--- a/scripts/setup_windows.ps1
+++ b/scripts/setup_windows.ps1
@@ -324,14 +324,19 @@ function Build-Project {
         }
 
         Write-Info "Running build..."
-        npx tauri build
+        tauri build
 
         $buildSuccess = $LASTEXITCODE -eq 0
 
         if ($buildSuccess) {
-            $releaseDir = "$PSScriptRoot\ytapp\src-tauri\target\release"
-            Write-Success "Build completed successfully!"
-            Write-Host "You can find the executable in: $releaseDir" -ForegroundColor Green
+            $releaseDir = Join-Path $projectPath "src-tauri\target\release"
+            if (Test-Path $releaseDir) {
+                $releaseDir = (Resolve-Path $releaseDir).Path
+                Write-Success "Build completed successfully!"
+                Write-Host "You can find the executable in: $releaseDir" -ForegroundColor Green
+            } else {
+                Write-WarningMsg "Build succeeded but release directory not found at $releaseDir"
+            }
             return $true
         } else {
             Write-Err "Build failed. Check the error messages above for details."
@@ -525,7 +530,7 @@ if ($allToolsInstalled) {
         Write-Host "`nDependencies were installed, but the project build failed." -ForegroundColor Yellow
         Write-Host "You can try building manually with:" -ForegroundColor Yellow
         Write-Host "  cd ytapp" -ForegroundColor Yellow
-        Write-Host "  npx tauri build" -ForegroundColor Yellow
+        Write-Host "  tauri build" -ForegroundColor Yellow
         exit 1
     }
 } else {


### PR DESCRIPTION
## Summary
- run `tauri build` directly instead of `npx`
- verify the release directory exists and report its path
- update manual build instructions

## Testing
- `npx --yes ts-node --project ytapp/tsconfig.json scripts/generate-schema.ts`
- `cd ytapp && npm install`
- `cd src-tauri && cargo check` *(fails: glib-2.0.pc not found)*
- `cd .. && npx --yes ts-node src/cli.ts --help`

------
https://chatgpt.com/codex/tasks/task_e_6871bc6de2748331adcd3166db2afc0c